### PR TITLE
feat(search): implement tt cut-offs

### DIFF
--- a/src/rose/engine.cpp
+++ b/src/rose/engine.cpp
@@ -17,6 +17,7 @@ namespace rose {
     const std::unique_lock _{m_shared->mutex};
     m_active_color = Color::white;
     m_shared->movegen_precomp = PrecompMoveGenInfo{};
+    m_shared->transposition_table.clear();
     for (const auto &search : m_searches)
       search->reset();
   }

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -107,6 +107,9 @@ namespace rose {
     return std::nullopt;
   }
 
+  inline auto Search::ttLoad(int ply) const -> tt::LookupResult { return m_shared.transposition_table.load(m_game.hash(), ply); }
+  inline auto Search::ttStore(int ply, tt::LookupResult lr) -> void { m_shared.transposition_table.store(m_game.hash(), ply, lr); }
+
   template <typename Controls> auto Search::search(const Controls &ctrl, Line &pv, i32 alpha, i32 beta, i32 ply, i32 depth) -> i32 {
     const bool is_in_check = m_game.position().isInCheck();
 
@@ -123,6 +126,23 @@ namespace rose {
     if (ply >= max_search_ply) [[unlikely]]
       return is_in_check ? 0 : eval::hce(m_game.position());
 
+    const auto tte = ttLoad(ply);
+    if (tte.depth >= depth && [&] {
+          switch (tte.bound) {
+          case tt::Bound::none:
+            return false;
+          case tt::Bound::lower_bound:
+            return tte.score >= beta;
+          case tt::Bound::exact:
+            return true;
+          case tt::Bound::upper_bound:
+            return tte.score <= alpha;
+          }
+        }()) {
+      pv.write(tte.move);
+      return tte.score;
+    }
+
     MoveList moves;
     {
       MoveGen movegen{m_game.position(), m_shared.movegen_precomp};
@@ -133,6 +153,9 @@ namespace rose {
       return is_in_check ? eval::mated(ply) : 0;
 
     i32 best_score = eval::no_moves;
+    Move best_move = tte.move;
+    tt::Bound tt_bound = tt::Bound::upper_bound;
+
     for (const auto m : moves) {
       m_game.move(m);
       rose_defer { m_game.unmove(); };
@@ -147,12 +170,23 @@ namespace rose {
         best_score = child_score;
         if (child_score > alpha) {
           alpha = child_score;
+          best_move = m;
+          tt_bound = tt::Bound::exact;
           pv.write(m, std::move(child_pv));
-          if (child_score >= beta)
+          if (child_score >= beta) {
+            tt_bound = tt::Bound::lower_bound;
             break;
+          }
         }
       }
     }
+
+    ttStore(ply, {
+                     .depth = depth,
+                     .bound = tt_bound,
+                     .score = best_score,
+                     .move = best_move,
+                 });
 
     return best_score;
   }

--- a/src/rose/search.h
+++ b/src/rose/search.h
@@ -12,6 +12,7 @@
 #include "rose/movegen.h"
 #include "rose/search_control.h"
 #include "rose/search_stats.h"
+#include "rose/tt.h"
 #include "rose/util/types.h"
 
 namespace rose {
@@ -26,6 +27,8 @@ namespace rose {
 
     std::vector<SearchStats> stats;
     PrecompMoveGenInfo movegen_precomp;
+
+    tt::TT transposition_table{tt::default_hash_size_mb};
 
     inline auto totalNodes() const -> u64 {
       u64 nodes = 0;
@@ -65,6 +68,8 @@ namespace rose {
     template <typename Controls> auto searchRoot(const Controls &ctrl) -> void;
 
     inline auto isDraw(bool is_in_check, i32 ply) -> std::optional<i32>;
+    inline auto ttLoad(int ply) const -> tt::LookupResult;
+    inline auto ttStore(int ply, tt::LookupResult lr) -> void;
 
     template <typename Controls> auto search(const Controls &ctrl, Line &pv, i32 alpha, i32 beta, i32 depth, i32 ply) -> i32;
   };

--- a/src/rose/tt.cpp
+++ b/src/rose/tt.cpp
@@ -1,0 +1,65 @@
+#include "rose/tt.h"
+
+#include <bit>
+#include <cstdlib>
+#include <cstring>
+#include <optional>
+
+#include "rose/common.h"
+#include "rose/util/types.h"
+#include "rose/util/vec.h"
+
+namespace rose::tt {
+
+  static constexpr inline auto splitHash(usize bucket_count, u64 hash) -> std::tuple<usize, u8, u64> {
+    const u128 mul = static_cast<u128>(hash) * bucket_count;
+    const usize index = static_cast<usize>(mul >> 64);
+    const u8 ctrl = static_cast<u8>(static_cast<u64>(mul) >> 56);
+    const u64 fragment = (static_cast<u64>(mul) >> (56 - Entry::fragment_width)) & Entry::fragment_mask;
+    return {index, ctrl, fragment};
+  }
+
+  static auto getEntryIndex(const Bucket &bucket, u8 ctrl) -> std::optional<usize> {
+    const u16 matches = vec::eq8(bucket.ctrls, v128::broadcast8(ctrl));
+    const usize index = std::countr_zero(matches);
+    return index < Bucket::entry_count ? std::optional<usize>{index} : std::nullopt;
+  }
+
+  auto TT::bucket_alloc(std::size_t bucket_count) -> Bucket * {
+    return static_cast<Bucket *>(std::aligned_alloc(4096, bucket_count * sizeof(Bucket)));
+  }
+
+  auto TT::bucket_free(Bucket *ptr) -> void { return std::free(ptr); }
+
+  auto TT::clear() -> void { std::memset(buckets.get(), 0, bucket_count * sizeof(Bucket)); }
+
+  auto TT::load(u64 hash, int ply) const -> LookupResult {
+    const auto [bucket_index, ctrl, fragment] = splitHash(bucket_count, hash);
+    const Bucket &bucket = buckets.get()[bucket_index];
+
+    if (const auto entry_index = getEntryIndex(bucket, ctrl)) {
+      const Entry &entry = bucket.entries[*entry_index];
+      if (entry.fragment() == fragment) {
+        return entry.toResult(ply);
+      }
+    }
+    return {};
+  }
+
+  auto TT::store(u64 hash, int ply, LookupResult lr) -> void {
+    const auto [bucket_index, ctrl, fragment] = splitHash(bucket_count, hash);
+    Bucket &bucket = buckets.get()[bucket_index];
+
+    const usize entry_index = getEntryIndex(bucket, ctrl)
+                                  .or_else([&] {
+                                    const usize res = bucket.ctrls.b.back();
+                                    bucket.ctrls.b.back() = (res + 1) % Bucket::entry_count;
+                                    return std::optional<usize>{res};
+                                  })
+                                  .value();
+
+    bucket.ctrls.b[entry_index] = ctrl;
+    bucket.entries[entry_index] = Entry{fragment, ply, lr};
+  }
+
+} // namespace rose::tt

--- a/src/rose/tt.h
+++ b/src/rose/tt.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <array>
+#include <optional>
+#include <tuple>
+
+#include "rose/eval/eval.h"
+#include "rose/move.h"
+#include "rose/util/types.h"
+#include "rose/util/vec.h"
+
+namespace rose::tt {
+
+  inline constexpr usize default_hash_size_mb = 64;
+
+  enum class Bound {
+    none = 0b00,
+    lower_bound = 0b01,
+    exact = 0b10,
+    upper_bound = 0b11,
+  };
+
+  struct LookupResult {
+    i32 depth = 0;
+    Bound bound = Bound::none;
+    i32 score = 0;
+    Move move = Move::none();
+  };
+
+  struct Entry {
+    // MSB -> LSB
+    // i16 score
+    // u16 move
+    // u8 depth
+    // u2 bounds
+    // u22 fragment
+    static inline constexpr usize fragment_width = 22;
+    static inline constexpr usize bounds_shift = 22;
+    static inline constexpr usize depth_shift = 24;
+    static inline constexpr usize move_shift = 32;
+    static inline constexpr usize score_shift = 48;
+    static inline constexpr u64 fragment_mask = (static_cast<u64>(1) << fragment_width) - 1;
+
+    u64 raw = 0;
+
+    constexpr Entry(u64 fragment, i32 ply, LookupResult lr) {
+      const i32 tt_score = eval::adjustPlysToMate(lr.score, -ply);
+      const i32 tt_depth = std::clamp(lr.depth, 0, 255);
+      const u64 tt_bound = std::to_underlying(lr.bound);
+
+      rose_assert((fragment & fragment_mask) == fragment);
+
+      raw = 0;
+      raw |= fragment;
+      raw |= static_cast<u64>(tt_bound) << bounds_shift;
+      raw |= static_cast<u64>(tt_depth) << depth_shift;
+      raw |= static_cast<u64>(lr.move.raw) << move_shift;
+      raw |= static_cast<u64>(tt_score) << score_shift;
+    }
+
+    constexpr inline auto fragment() const -> u64 { return raw & fragment_mask; }
+    constexpr inline auto bound() const -> Bound { return static_cast<Bound>((raw >> bounds_shift) & 3); }
+    constexpr inline auto depth() const -> u8 { return static_cast<u8>(raw >> depth_shift); }
+    constexpr inline auto move() const -> Move { return Move{static_cast<u16>(raw >> move_shift)}; }
+    constexpr inline auto score(i32 ply) const -> i32 {
+      const i32 tt_score = static_cast<i32>(static_cast<i64>(raw) >> score_shift);
+      return eval::adjustPlysToMate(tt_score, +ply);
+    }
+
+    constexpr auto toResult(i32 ply) const -> LookupResult {
+      return {
+          .depth = depth(),
+          .bound = bound(),
+          .score = score(ply),
+          .move = move(),
+      };
+    }
+  };
+  static_assert(sizeof(Entry) == sizeof(u64));
+
+  struct Bucket {
+    static inline constexpr usize entry_count = 14;
+    v128 ctrls;
+    std::array<Entry, entry_count> entries;
+  };
+  static_assert(sizeof(Bucket) == sizeof(u64) * 16);
+
+  constexpr inline auto megabytesToBucketCount(usize mb) -> usize { return mb * 1024 * 1024 / sizeof(Bucket); }
+
+  struct TT {
+  private:
+    static auto bucket_alloc(std::size_t bucket_count) -> Bucket *;
+    static auto bucket_free(Bucket *ptr) -> void;
+
+    usize bucket_count;
+    std::unique_ptr<Bucket, decltype(&bucket_free)> buckets;
+
+  public:
+    explicit TT(usize mb) : bucket_count{megabytesToBucketCount(mb)}, buckets{bucket_alloc(bucket_count), &bucket_free} {}
+    auto resize(usize mb) -> void {
+      bucket_count = megabytesToBucketCount(mb);
+      buckets = {bucket_alloc(bucket_count), &bucket_free};
+    }
+
+    auto clear() -> void;
+
+    auto load(u64 hash, int ply) const -> LookupResult;
+    auto store(u64 hash, int ply, LookupResult lr) -> void;
+  };
+
+} // namespace rose::tt

--- a/src/rose/uci.cpp
+++ b/src/rose/uci.cpp
@@ -154,6 +154,7 @@ namespace rose {
   static auto uciParseNewGame(Engine &engine, Game &game, Tokenizer &it) -> void {
     game.reset();
     engine.reset();
+    engine.setGame(game);
   }
 
   static auto uciParseIsReady(Engine &engine, Game &game, Tokenizer &it) -> void {


### PR DESCRIPTION
```
Elo   | 42.96 +- 20.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 10.00]
Games | N: 764 W: 309 L: 215 D: 240
Penta | [34, 57, 125, 113, 53]
```