### PR TITLE
feat(search): apply maluses to basic history (beta-cutoff only)

### DIFF
--- a/src/rose/history.cpp
+++ b/src/rose/history.cpp
@@ -12,6 +12,7 @@ namespace rose {
 
   auto History::updateQuietHistory(i32 sign, Move m, i32 depth) -> void {
     rose_assert(sign == +1 || sign == -1);
+    rose_assert(!m.capture());
 
     constexpr i32 k = tunable::history_bonus_scale;
     constexpr i32 c = tunable::history_bonus_const;

--- a/src/rose/move_picker.h
+++ b/src/rose/move_picker.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "rose/move.h"
 #include "rose/movegen.h"
 #include "rose/util/types.h"
@@ -28,10 +30,18 @@ namespace rose {
     std::span<Move> m_noisy;
     std::span<Move> m_quiet;
 
+    usize m_quiet_marker = 1;
+
   public:
     MovePicker(const Search &search, Move tt_move);
 
     auto next() -> Move;
+
+    auto setMarker() -> void {
+      if (m_stage == Stage::emit_quiet)
+        m_quiet_marker = std::max<usize>(1, m_current_index);
+    }
+    auto getMarkedQuiets() const -> std::span<Move> { return m_quiet.subspan(0, m_quiet_marker - 1); }
 
   private:
     auto generateMoves() -> void;

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -204,6 +204,7 @@ namespace rose {
           alpha = child_score;
           best_move = m;
           tt_bound = tt::Bound::exact;
+          moves.setMarker();
 
           if constexpr (NodeT::is_pv)
             pv.write(m, std::move(child_pv));
@@ -221,6 +222,10 @@ namespace rose {
 
     if (best_score >= beta && !best_move.capture()) {
       m_history.updateQuietHistory(+1, best_move, depth);
+
+      const std::span<Move> bad_moves = moves.getMarkedQuiets();
+      for (Move badm : bad_moves)
+        m_history.updateQuietHistory(-1, badm, depth);
     }
 
     ttStore(ply, {


### PR DESCRIPTION
```
Elo   | 58.45 +- 24.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 10.00]
Games | N: 576 W: 279 L: 183 D: 114
Penta | [28, 25, 115, 63, 57]
```