### PR TITLE
fix(search): fix next nodetype

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -30,16 +30,19 @@ namespace rose {
     struct Root {
       inline static constexpr bool is_root = true;
       inline static constexpr bool is_pv = true;
+      using Next = Pv;
     };
 
     struct Pv {
       inline static constexpr bool is_root = false;
       inline static constexpr bool is_pv = true;
+      using Next = Pv;
     };
 
     struct NonPv {
       inline static constexpr bool is_root = false;
       inline static constexpr bool is_pv = false;
+      using Next = NonPv;
     };
   } // namespace nodetype
 
@@ -228,7 +231,7 @@ namespace rose {
             return scout_score;
         }
 
-        return -search<NodeT>(ctrl, child_position, child_pv, -beta, -alpha, ply + 1, depth - 1);
+        return -search<typename NodeT::Next>(ctrl, child_position, child_pv, -beta, -alpha, ply + 1, depth - 1);
       }();
 
       moves_searched++;


### PR DESCRIPTION
```
Elo   | 0.32 +- 6.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-10.00, 0.00]
Games | N: 6462 W: 2309 L: 2303 D: 1850
Penta | [326, 628, 1306, 656, 315]
```