### PR TITLE
perf(static_vector): turn size check into assert

### DIFF
--- a/src/rose/util/static_vector.h
+++ b/src/rose/util/static_vector.h
@@ -34,8 +34,7 @@ namespace rose {
     }
 
     constexpr auto push_back(const T &value) -> iterator {
-      if (len >= cap)
-        return end();
+      rose_assert(len < cap);
       data[len] = value;
       return &data[len++];
     }


### PR DESCRIPTION
```
Elo   | 2.56 +- 4.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 1.00]
Games | N: 10854 W: 4096 L: 4016 D: 2742
Penta | [525, 922, 2475, 958, 547]
```