### PR TITLE
feat(search): evasions in qs

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -301,7 +301,8 @@ namespace rose {
     alpha = std::max(alpha, static_eval);
 
     MovePicker moves{*this, position, Move::none()};
-    moves.skipQuiets();
+    if (!is_in_check)
+      moves.skipQuiets();
 
     i32 best_score = static_eval;
     Move best_move = Move::none();


### PR DESCRIPTION
```
Elo   | 88.74 +- 30.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 10.00]
Games | N: 356 W: 154 L: 65 D: 137
Penta | [4, 32, 55, 45, 42]
```