### PR TITLE
fix(search): don't update line in non-pv node

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -184,7 +184,6 @@ namespace rose {
               return tte.score <= alpha;
             }
           }()) {
-        pv.write(tte.move);
         return tte.score;
       }
 


### PR DESCRIPTION
```
Elo   | -0.43 +- 4.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-10.00, 0.00]
Games | N: 8118 W: 2204 L: 2214 D: 3700
Penta | [216, 879, 1874, 879, 211]
```