### PR TITLE
feat(search): mate distance pruning

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -169,6 +169,14 @@ namespace rose {
     if (ply >= max_search_ply) [[unlikely]]
       return is_in_check ? 0 : eval::hce(position);
 
+    // Mate distance pruning
+    if constexpr (!NodeT::is_root) {
+      alpha = std::max(alpha, eval::mated(ply));
+      beta = std::min(beta, eval::mating(ply + 1));
+      if (alpha >= beta)
+        return alpha;
+    }
+
     const auto tte = ttLoad(position, ply);
 
     if constexpr (!NodeT::is_pv) {


### PR DESCRIPTION
```
Elo   | -1.31 +- 3.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-9.00, 1.00]
Games | N: 17248 W: 4670 L: 4735 D: 7843
Penta | [481, 1934, 3846, 1895, 468]
```