### PR TITLE
feat(search): late move pruning

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -266,6 +266,12 @@ namespace rose {
           }
         }
       }
+
+      if (!NodeT::is_pv && !is_in_check && best_score >= eval::min_normal_score) {
+        // Late move pruning
+        if (moves_searched >= tunable::lmp_base + depth * depth / tunable::lmp_scale)
+          moves.skipQuiets();
+      }
     }
 
     if (moves_searched == 0)

--- a/src/rose/tunable.h
+++ b/src/rose/tunable.h
@@ -17,4 +17,7 @@ namespace rose::tunable {
   inline constexpr i32 rfp_max_depth = 6;
   inline constexpr i32 rfp_margin = 100;
 
+  inline constexpr i32 lmp_base = 3;
+  inline constexpr i32 lmp_scale = 1;
+
 } // namespace rose::tunable


### PR DESCRIPTION
```
Elo   | 12.93 +- 9.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 10.00]
Games | N: 3198 W: 1090 L: 971 D: 1137
Penta | [147, 344, 544, 371, 193]
```