### PR TITLE
feat(search): null move reductions

### DIFF
--- a/src/rose/position.cpp
+++ b/src/rose/position.cpp
@@ -50,6 +50,17 @@ namespace rose {
     return false;
   }
 
+  auto Position::moveNull() const -> Position {
+    Position new_pos = *this;
+
+    new_pos.m_hash ^= hash::move;
+    new_pos.m_ply++;
+    new_pos.m_enpassant = Square::invalid();
+    new_pos.m_active_color = m_active_color.invert();
+
+    return new_pos;
+  }
+
   auto Position::move(Move m) const -> Position {
     Position new_pos = *this;
 

--- a/src/rose/position.h
+++ b/src/rose/position.h
@@ -84,6 +84,7 @@ namespace rose {
 
     auto isRepetition(const std::vector<u64> &hash_stack, usize hash_waterline) const -> bool;
 
+    auto moveNull() const -> Position;
     auto move(Move m) const -> Position;
 
     auto calcAttacksSlow() const -> std::array<Wordboard, 2>;

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -30,19 +30,29 @@ namespace rose {
     struct Root {
       inline static constexpr bool is_root = true;
       inline static constexpr bool is_pv = true;
+      inline static constexpr bool is_nmr = false;
       using Next = Pv;
     };
 
     struct Pv {
       inline static constexpr bool is_root = false;
       inline static constexpr bool is_pv = true;
+      inline static constexpr bool is_nmr = false;
       using Next = Pv;
     };
 
     struct NonPv {
       inline static constexpr bool is_root = false;
       inline static constexpr bool is_pv = false;
+      inline static constexpr bool is_nmr = false;
       using Next = NonPv;
+    };
+
+    struct Nmred {
+      inline static constexpr bool is_root = false;
+      inline static constexpr bool is_pv = false;
+      inline static constexpr bool is_nmr = true;
+      using Next = Nmred;
     };
   } // namespace nodetype
 
@@ -201,6 +211,29 @@ namespace rose {
         // Reverse futility pruning
         if (depth <= tunable::rfp_max_depth && static_eval - tunable::rfp_margin * depth >= beta)
           return static_eval;
+
+        if (depth >= tunable::nmr_min_depth && static_eval >= beta) {
+          const i32 null_score = [&] {
+            const Position child_position = position.moveNull();
+            m_hash_stack.push_back(child_position.hash());
+            m_move_stack.push_back(Move::none());
+            rose_defer {
+              m_hash_stack.pop_back();
+              m_move_stack.pop_back();
+            };
+            const i32 reduction = tunable::nmr_zws_base;
+            Line child_pv{};
+            return -search<nodetype::NonPv>(ctrl, child_position, child_pv, -beta, -(beta - 1), ply, depth - reduction);
+          }();
+
+          if (null_score >= beta) {
+            if constexpr (NodeT::is_nmr)
+              return eval::isTheoretical(null_score) ? beta : null_score;
+
+            depth -= tunable::nmr_reduction_base;
+            return search<nodetype::Nmred>(ctrl, position, pv, alpha, beta, ply, depth);
+          }
+        }
       }
     }
 

--- a/src/rose/tunable.h
+++ b/src/rose/tunable.h
@@ -20,4 +20,8 @@ namespace rose::tunable {
   inline constexpr i32 lmp_base = 3;
   inline constexpr i32 lmp_scale = 1;
 
+  inline constexpr i32 nmr_min_depth = 4;
+  inline constexpr i32 nmr_zws_base = 4;
+  inline constexpr i32 nmr_reduction_base = 2;
+
 } // namespace rose::tunable


### PR DESCRIPTION
performed better than r=3 nmp or r=3 nmr

```
Elo   | 66.35 +- 24.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 10.00]
Games | N: 424 W: 149 L: 69 D: 206
Penta | [6, 30, 82, 66, 28]
```