### PR TITLE
feat(move_picker): Separate good and bad noisies

### DIFF
--- a/src/rose/move_picker.cpp
+++ b/src/rose/move_picker.cpp
@@ -7,6 +7,8 @@
 
 #include "rose/common.h"
 #include "rose/search.h"
+#include "rose/see.h"
+#include "rose/tunable.h"
 #include "rose/util/static_vector.h"
 
 namespace rose {
@@ -15,7 +17,7 @@ namespace rose {
 
   auto MovePicker::skipQuiets() -> void {
     if (m_stage == Stage::emit_quiet)
-      m_stage = Stage::end;
+      m_stage = Stage::emit_bad_noisy;
     m_skip_quiets = true;
   }
 
@@ -31,15 +33,23 @@ namespace rose {
       generateMoves();
 
       sortNoisy();
-      m_stage = Stage::emit_noisy;
+      m_stage = Stage::emit_good_noisy;
       m_current_index = 0;
 
       [[fallthrough]];
-    case Stage::emit_noisy:
-      if (m_current_index < m_noisy.size() && m_noisy[m_current_index] == m_tt_move)
-        m_current_index++;
-      if (m_current_index < m_noisy.size())
+    case Stage::emit_good_noisy:
+      while (m_current_index < m_noisy.size()) {
+        if (m_noisy[m_current_index] == m_tt_move) {
+          m_current_index++;
+          continue;
+        }
+        if (!see::see(m_position, m_noisy[m_current_index], tunable::bad_noisy_see_threshold)) {
+          m_bad_noisy.push_back(m_noisy[m_current_index]);
+          m_current_index++;
+          continue;
+        }
         return m_noisy[m_current_index++];
+      }
 
       if (m_skip_quiets) {
         m_stage = Stage::end;
@@ -56,6 +66,16 @@ namespace rose {
         m_current_index++;
       if (m_current_index < m_quiet.size())
         return m_quiet[m_current_index++];
+
+      m_stage = Stage::emit_bad_noisy;
+      m_current_index = 0;
+
+      [[fallthrough]];
+    case Stage::emit_bad_noisy:
+      if (m_current_index < m_bad_noisy.size() && m_bad_noisy[m_current_index] == m_tt_move)
+        m_current_index++;
+      if (m_current_index < m_bad_noisy.size())
+        return m_bad_noisy[m_current_index++];
 
       m_stage = Stage::end;
 

--- a/src/rose/move_picker.h
+++ b/src/rose/move_picker.h
@@ -16,8 +16,9 @@ namespace rose {
     enum class Stage {
       tt_move,
       generate_moves,
-      emit_noisy,
+      emit_good_noisy,
       emit_quiet,
+      emit_bad_noisy,
       end,
     };
 
@@ -31,6 +32,7 @@ namespace rose {
     MoveList m_moves;
     std::span<Move> m_noisy;
     std::span<Move> m_quiet;
+    MoveList m_bad_noisy;
 
     bool m_skip_quiets = false;
     usize m_quiet_marker = 0;

--- a/src/rose/tunable.h
+++ b/src/rose/tunable.h
@@ -25,5 +25,6 @@ namespace rose::tunable {
   inline constexpr i32 nmr_reduction_base = 2;
 
   inline constexpr i32 qs_see_threshold = 0;
+  inline constexpr i32 bad_noisy_see_threshold = -150;
 
 } // namespace rose::tunable


### PR DESCRIPTION
```
Elo   | 69.58 +- 25.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 10.00]
Games | N: 420 W: 144 L: 61 D: 215
Penta | [6, 33, 73, 68, 30]

bench results:
nodes: 31204768 nodes
time:  10251 milliseconds
nps:   3043931 nps
```