### PR TITLE
fix(move_picker): Advance to emit_bad_noisy if skip_quiet after emit_good_noisy

### DIFF
--- a/src/rose/move_picker.cpp
+++ b/src/rose/move_picker.cpp
@@ -52,7 +52,7 @@ namespace rose {
       }
 
       if (m_skip_quiets) {
-        m_stage = Stage::end;
+        m_stage = Stage::emit_bad_noisy;
         return Move::none();
       }
 


### PR DESCRIPTION
```
Elo   | -1.01 +- 3.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.11 (-2.25, 2.89) [-10.00, 0.00]
Games | N: 11406 W: 2413 L: 2446 D: 6547
Penta | [181, 1265, 2837, 1246, 174]

bench results:
nodes: 31204768 nodes
time:  10414 milliseconds
nps:   2996364 nps
```