### PR TITLE
feat(search): Add killer move 

### DIFF
--- a/src/rose/move_picker.cpp
+++ b/src/rose/move_picker.cpp
@@ -52,7 +52,7 @@ namespace rose {
       }
 
       if (m_skip_quiets) {
-        m_stage = Stage::end;
+        m_stage = Stage::emit_bad_noisy;
         return Move::none();
       }
 

--- a/src/rose/move_picker.cpp
+++ b/src/rose/move_picker.cpp
@@ -13,10 +13,11 @@
 
 namespace rose {
 
-  MovePicker::MovePicker(const Search &search, const Position &position, Move tt_move) : m_search(search), m_position(position), m_tt_move(tt_move) {}
+  MovePicker::MovePicker(const Search &search, const Position &position, Move tt_move, Move killer)
+      : m_search(search), m_position(position), m_tt_move(tt_move), m_killer(killer) {}
 
   auto MovePicker::skipQuiets() -> void {
-    if (m_stage == Stage::emit_quiet)
+    if (is_in_quiet_stage())
       m_stage = Stage::emit_bad_noisy;
     m_skip_quiets = true;
   }
@@ -123,6 +124,12 @@ namespace rose {
     }
 
     std::ranges::sort(std::ranges::zip_view(m_quiet, quiet_scores), [](auto &&a, auto &&b) { return std::get<1>(a) > std::get<1>(b); });
+
+    if (m_killer != Move::none()) {
+      const auto it = std::find(m_quiet.begin(), m_quiet.end(), m_killer);
+      if (it != m_quiet.end())
+        std::rotate(m_quiet.begin(), it, it + 1);
+    }
   }
 
 } // namespace rose

--- a/src/rose/move_picker.h
+++ b/src/rose/move_picker.h
@@ -22,11 +22,14 @@ namespace rose {
       end,
     };
 
+    auto is_in_quiet_stage() const -> bool { return m_stage > Stage::emit_good_noisy && m_stage < Stage::emit_bad_noisy; }
+
     Stage m_stage = Stage::tt_move;
 
     const Search &m_search;
     const Position &m_position;
     Move m_tt_move;
+    Move m_killer;
 
     usize m_current_index = 0;
     MoveList m_moves;
@@ -38,7 +41,7 @@ namespace rose {
     usize m_quiet_marker = 0;
 
   public:
-    MovePicker(const Search &search, const Position &position, Move tt_move);
+    MovePicker(const Search &search, const Position &position, Move tt_move, Move killer);
 
     auto skipQuiets() -> void;
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -218,7 +218,7 @@ namespace rose {
             };
             const i32 reduction = tunable::nmr_zws_base;
             Line child_pv{};
-            return -search<nodetype::NonPv>(ctrl, child_position, child_pv, -beta, -(beta - 1), ss, depth - reduction);
+            return -search<nodetype::NonPv>(ctrl, child_position, child_pv, -beta, -(beta - 1), ss + 1, depth - reduction);
           }();
 
           if (null_score >= beta) {

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -114,6 +114,8 @@ namespace rose {
     i32 last_score;
     i32 last_depth;
 
+    search_stack[0].killer = Move::none();
+
     for (i32 depth = 1; depth < max_search_ply; depth++) {
       Line pv{};
       const i32 score = search<nodetype::Root>(ctrl, m_root, pv, eval::min_score, eval::max_score, &search_stack[0], depth);
@@ -232,12 +234,14 @@ namespace rose {
       }
     }
 
-    MovePicker moves{*this, position, tte.move};
+    MovePicker moves{*this, position, tte.move, ss->killer};
 
     i32 best_score = eval::no_moves;
     Move best_move = tte.move;
     tt::Bound tt_bound = tt::Bound::upper_bound;
     usize moves_searched = 0;
+
+    (ss + 1)->killer = Move::none();
 
     for (Move m = moves.next(); m != Move::none(); m = moves.next()) {
       const bool is_quiet_move = !m.capture();
@@ -318,7 +322,10 @@ namespace rose {
 
       const std::span<Move> bad_moves = moves.getMarkedQuiets();
       for (Move badm : bad_moves)
-        m_history.updateQuietHistory(-1, badm, depth);
+        if (badm != ss->killer)
+          m_history.updateQuietHistory(-1, badm, depth);
+
+      ss->killer = best_move;
     }
 
     ttStore(position, ply,
@@ -351,7 +358,7 @@ namespace rose {
       return static_eval;
     alpha = std::max(alpha, static_eval);
 
-    MovePicker moves{*this, position, Move::none()};
+    MovePicker moves{*this, position, Move::none(), Move::none()};
     if (!is_in_check)
       moves.skipQuiets();
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -100,6 +100,10 @@ namespace rose {
   }
 
   template <typename Controls> auto Search::searchRoot(const Controls &ctrl) -> void {
+    StaticVector<SearchStackEntry, max_search_ply + 1> search_stack;
+    for (i32 i = 0; i < max_search_ply + 1; i++)
+      search_stack[i].ply = i;
+
     const auto print_info = [this, &ctrl](i32 depth, i32 score, const Line &pv) {
       const u64 nodes = m_shared.totalNodes();
       const time::Duration elapsed = ctrl.elapsed();
@@ -112,7 +116,7 @@ namespace rose {
 
     for (i32 depth = 1; depth < max_search_ply; depth++) {
       Line pv{};
-      const i32 score = search<nodetype::Root>(ctrl, m_root, pv, eval::min_score, eval::max_score, 0, depth);
+      const i32 score = search<nodetype::Root>(ctrl, m_root, pv, eval::min_score, eval::max_score, &search_stack[0], depth);
 
       if (hasStopped())
         break;
@@ -148,10 +152,11 @@ namespace rose {
   }
 
   template <typename NodeT, typename Controls>
-  auto Search::search(const Controls &ctrl, const Position &position, Line &pv, i32 alpha, i32 beta, i32 ply, i32 depth) -> i32 {
+  auto Search::search(const Controls &ctrl, const Position &position, Line &pv, i32 alpha, i32 beta, SearchStackEntry *ss, i32 depth) -> i32 {
+    const i32 ply = ss->ply;
 
     if (depth <= 0)
-      return quiesce<NodeT>(ctrl, position, pv, alpha, beta, ply);
+      return quiesce<NodeT>(ctrl, position, pv, alpha, beta, ss);
 
     if (!NodeT::is_root && isMainThread() && ctrl.checkHardTermination(stats(), depth)) [[unlikely]] {
       requestStop();
@@ -213,7 +218,7 @@ namespace rose {
             };
             const i32 reduction = tunable::nmr_zws_base;
             Line child_pv{};
-            return -search<nodetype::NonPv>(ctrl, child_position, child_pv, -beta, -(beta - 1), ply, depth - reduction);
+            return -search<nodetype::NonPv>(ctrl, child_position, child_pv, -beta, -(beta - 1), ss, depth - reduction);
           }();
 
           if (null_score >= beta) {
@@ -221,7 +226,7 @@ namespace rose {
               return eval::isTheoretical(null_score) ? beta : null_score;
 
             depth -= tunable::nmr_reduction_base;
-            return search<nodetype::Nmred>(ctrl, position, pv, alpha, beta, ply, depth);
+            return search<nodetype::Nmred>(ctrl, position, pv, alpha, beta, ss, depth);
           }
         }
       }
@@ -262,7 +267,7 @@ namespace rose {
           i32 reduction = (tunable::lmr_base_const + l2m * l2d) / tunable::lmr_base_scale;
           reduction = std::clamp(reduction, 1, depth - 1);
           if (reduction > 1) {
-            const i32 lmr_score = -search<nodetype::NonPv>(ctrl, child_position, child_pv, -(alpha + 1), -alpha, ply + 1, depth - reduction);
+            const i32 lmr_score = -search<nodetype::NonPv>(ctrl, child_position, child_pv, -(alpha + 1), -alpha, ss + 1, depth - reduction);
             if (lmr_score <= alpha)
               return lmr_score;
           }
@@ -270,13 +275,13 @@ namespace rose {
 
         // PVS scout search
         if (NodeT::is_pv && moves_searched > 0) {
-          const i32 scout_score = -search<nodetype::NonPv>(ctrl, child_position, child_pv, -(alpha + 1), -alpha, ply + 1, depth - 1);
+          const i32 scout_score = -search<nodetype::NonPv>(ctrl, child_position, child_pv, -(alpha + 1), -alpha, ss + 1, depth - 1);
           if (scout_score <= alpha)
             return scout_score;
         }
 
         // PVS full-window search
-        return -search<typename NodeT::Next>(ctrl, child_position, child_pv, -beta, -alpha, ply + 1, depth - 1);
+        return -search<typename NodeT::Next>(ctrl, child_position, child_pv, -beta, -alpha, ss + 1, depth - 1);
       }();
 
       moves_searched++;
@@ -328,7 +333,8 @@ namespace rose {
   }
 
   template <typename NodeT, typename Controls>
-  auto Search::quiesce(const Controls &ctrl, const Position &position, Line &pv, i32 alpha, i32 beta, i32 ply) -> i32 {
+  auto Search::quiesce(const Controls &ctrl, const Position &position, Line &pv, i32 alpha, i32 beta, SearchStackEntry *ss) -> i32 {
+    const i32 ply = ss->ply;
     const bool is_in_check = position.isInCheck();
 
     stats().nodes.fetch_add(1, std::memory_order::relaxed);
@@ -369,7 +375,7 @@ namespace rose {
       };
 
       Line child_pv{};
-      const i32 child_score = -quiesce<typename NodeT::Next>(ctrl, child_position, child_pv, -beta, -alpha, ply + 1);
+      const i32 child_score = -quiesce<typename NodeT::Next>(ctrl, child_position, child_pv, -beta, -alpha, ss + 1);
 
       moves_searched++;
 

--- a/src/rose/search.h
+++ b/src/rose/search.h
@@ -23,6 +23,7 @@ namespace rose {
 
   struct SearchStackEntry {
     i32 ply;
+    Move killer;
   };
 
   struct SearchShared {

--- a/src/rose/search.h
+++ b/src/rose/search.h
@@ -21,6 +21,10 @@
 
 namespace rose {
 
+  struct SearchStackEntry {
+    i32 ply;
+  };
+
   struct SearchShared {
     explicit SearchShared(int thread_count, std::shared_ptr<EngineOutput> output)
         : idle_barrier(1 + thread_count), started_barrier(1 + thread_count), stats(thread_count), output(output) {}
@@ -84,14 +88,14 @@ namespace rose {
     template <typename Controls> auto searchRoot(const Controls &ctrl) -> void;
 
     inline auto isRuleDraw(const Position &position, i32 ply) -> std::optional<i32>;
-    inline auto ttLoad(const Position &position, int ply) const -> tt::LookupResult;
-    inline auto ttStore(const Position &position, int ply, tt::LookupResult lr) -> void;
+    inline auto ttLoad(const Position &position, i32 ply) const -> tt::LookupResult;
+    inline auto ttStore(const Position &position, i32 ply, tt::LookupResult lr) -> void;
 
     template <typename NodeT, typename Controls>
-    auto search(const Controls &ctrl, const Position &position, Line &pv, i32 alpha, i32 beta, i32 ply, i32 depth) -> i32;
+    auto search(const Controls &ctrl, const Position &position, Line &pv, i32 alpha, i32 beta, SearchStackEntry *ss, i32 depth) -> i32;
 
     template <typename NodeT, typename Controls>
-    auto quiesce(const Controls &ctrl, const Position &position, Line &pv, i32 alpha, i32 beta, i32 ply) -> i32;
+    auto quiesce(const Controls &ctrl, const Position &position, Line &pv, i32 alpha, i32 beta, SearchStackEntry *ss) -> i32;
   };
 
 } // namespace rose


### PR DESCRIPTION
```
Elo   | 26.53 +- 13.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 10.00]
Games | N: 958 W: 236 L: 163 D: 559
Penta | [14, 89, 210, 142, 24]

bench results:
nodes: 31134809 nodes
time:  10361 milliseconds
nps:   3004994 nps
```