### PR TITLE
Add movepicker

### DIFF
--- a/src/rose/cmd/bench.cpp
+++ b/src/rose/cmd/bench.cpp
@@ -23,7 +23,7 @@ namespace rose::bench {
     }
   };
 
-  static constexpr int bench_depth = 6;
+  static constexpr int bench_depth = 5;
   static constexpr std::array<std::string_view, 40> bench_fens {{
     "1k1r2r1/pp3p2/3p4/1b2q3/3QP1pp/8/PB3PPP/2R1R1K1 w - - 0 1",
     "1R6/5pk1/4r3/5pPp/1p6/8/1PK5/8 b - - 0 1",

--- a/src/rose/cmd/bench.cpp
+++ b/src/rose/cmd/bench.cpp
@@ -23,7 +23,7 @@ namespace rose::bench {
     }
   };
 
-  static constexpr int bench_depth = 5;
+  static constexpr int bench_depth = 6;
   static constexpr std::array<std::string_view, 40> bench_fens {{
     "1k1r2r1/pp3p2/3p4/1b2q3/3QP1pp/8/PB3PPP/2R1R1K1 w - - 0 1",
     "1R6/5pk1/4r3/5pPp/1p6/8/1PK5/8 b - - 0 1",

--- a/src/rose/cmd/perft.cpp
+++ b/src/rose/cmd/perft.cpp
@@ -17,9 +17,7 @@ namespace rose::perft {
 
     u64 result = 0;
 
-    MoveList moves;
-    MoveGen movegen {position};
-    movegen.generate_moves(moves);
+    const MoveList moves = generate_all_moves(position);
 
     if (!print && depth == 1 && bulk)
       return moves.size();

--- a/src/rose/move.hpp
+++ b/src/rose/move.hpp
@@ -41,7 +41,7 @@ namespace rose {
 
     static constexpr auto none() -> Move {
       return Move {0};
-    };
+    }
 
     static constexpr auto make(Square from, Square to, MoveFlags flags) -> Move {
       rose_assert(from.is_valid() && to.is_valid());
@@ -51,6 +51,14 @@ namespace rose {
       result |= static_cast<u16>(to.raw) << 6;
       result |= static_cast<u16>(flags);
       return Move {result};
+    }
+
+    constexpr auto is_some() const -> bool {
+      return raw != 0;
+    }
+
+    constexpr auto is_none() const -> bool {
+      return raw == 0;
     }
 
     constexpr auto from() const -> Square {

--- a/src/rose/move_picker.cpp
+++ b/src/rose/move_picker.cpp
@@ -3,35 +3,41 @@
 #include "rose/movegen.hpp"
 #include "rose/search.hpp"
 
-#include <algorithm>
-
 namespace rose {
 
   MovePicker::MovePicker(const Search& search, const Position& position) :
       m_search(search),
-      m_position(position) {
+      m_position(position),
+      m_movegen(position) {
   }
 
   auto MovePicker::next() -> Move {
     switch (m_stage) {
-    case Stage::generate_moves:
-      generate_moves();
+    case Stage::generate_noisy:
+      generate_noisy();
 
       m_stage = Stage::emit_noisy;
       m_current_index = 0;
 
       [[fallthrough]];
     case Stage::emit_noisy:
-      if (m_current_index < m_noisy.size())
-        return m_noisy[m_current_index++];
+      if (m_current_index < m_moves.size())
+        return m_moves[m_current_index++];
+
+      m_stage = Stage::generate_quiet;
+      m_current_index = 0;
+
+      [[fallthrough]];
+    case Stage::generate_quiet:
+      generate_quiet();
 
       m_stage = Stage::emit_quiet;
       m_current_index = 0;
 
       [[fallthrough]];
     case Stage::emit_quiet:
-      if (m_current_index < m_quiet.size())
-        return m_quiet[m_current_index++];
+      if (m_current_index < m_moves.size())
+        return m_moves[m_current_index++];
 
       m_stage = Stage::end;
       m_current_index = 0;
@@ -43,17 +49,15 @@ namespace rose {
     }
   }
 
-  auto MovePicker::generate_moves() -> void {
+  auto MovePicker::generate_noisy() -> void {
     m_moves.clear();
+    m_movegen.prepare();
+    m_movegen.generate_noisy(m_moves);
+  }
 
-    MoveGen movegen {m_position};
-    movegen.generate_moves(m_moves);
-
-    const auto first_quiet = std::stable_partition(m_moves.begin(), m_moves.end(), [](Move m) {
-      return m.capture();
-    });
-    m_noisy = std::span {m_moves.begin(), first_quiet};
-    m_quiet = std::span {first_quiet, m_moves.end()};
+  auto MovePicker::generate_quiet() -> void {
+    m_moves.clear();
+    m_movegen.generate_quiet(m_moves);
   }
 
 }  // namespace rose

--- a/src/rose/move_picker.cpp
+++ b/src/rose/move_picker.cpp
@@ -1,11 +1,9 @@
 #include "rose/move_picker.hpp"
 
-#include "rose/common.hpp"
+#include "rose/movegen.hpp"
 #include "rose/search.hpp"
-#include "rose/util/static_vector.hpp"
 
 #include <algorithm>
-#include <ranges>
 
 namespace rose {
 

--- a/src/rose/move_picker.cpp
+++ b/src/rose/move_picker.cpp
@@ -1,0 +1,61 @@
+#include "rose/move_picker.hpp"
+
+#include "rose/common.hpp"
+#include "rose/search.hpp"
+#include "rose/util/static_vector.hpp"
+
+#include <algorithm>
+#include <ranges>
+
+namespace rose {
+
+  MovePicker::MovePicker(const Search& search, const Position& position) :
+      m_search(search),
+      m_position(position) {
+  }
+
+  auto MovePicker::next() -> Move {
+    switch (m_stage) {
+    case Stage::generate_moves:
+      generate_moves();
+
+      m_stage = Stage::emit_noisy;
+      m_current_index = 0;
+
+      [[fallthrough]];
+    case Stage::emit_noisy:
+      if (m_current_index < m_noisy.size())
+        return m_noisy[m_current_index++];
+
+      m_stage = Stage::emit_quiet;
+      m_current_index = 0;
+
+      [[fallthrough]];
+    case Stage::emit_quiet:
+      if (m_current_index < m_quiet.size())
+        return m_quiet[m_current_index++];
+
+      m_stage = Stage::end;
+      m_current_index = 0;
+
+      [[fallthrough]];
+    case Stage::end:
+    default:
+      return Move::none();
+    }
+  }
+
+  auto MovePicker::generate_moves() -> void {
+    m_moves.clear();
+
+    MoveGen movegen {m_position};
+    movegen.generate_moves(m_moves);
+
+    const auto first_quiet = std::stable_partition(m_moves.begin(), m_moves.end(), [](Move m) {
+      return m.capture();
+    });
+    m_noisy = std::span {m_moves.begin(), first_quiet};
+    m_quiet = std::span {first_quiet, m_moves.end()};
+  }
+
+}  // namespace rose

--- a/src/rose/move_picker.hpp
+++ b/src/rose/move_picker.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "rose/common.hpp"
+#include "rose/move.hpp"
+#include "rose/movegen.hpp"
+
+#include <span>
+
+namespace rose {
+
+  struct Search;
+
+  struct MovePicker {
+  private:
+    enum class Stage {
+      generate_moves,
+      emit_noisy,
+      emit_quiet,
+      end,
+    };
+
+    auto is_in_quiet_stage() const -> bool {
+      return m_stage == Stage::emit_quiet;
+    }
+
+    Stage m_stage = Stage::generate_moves;
+
+    const Search& m_search;
+    const Position& m_position;
+
+    usize m_current_index = 0;
+    MoveList m_moves;
+    std::span<Move> m_noisy;
+    std::span<Move> m_quiet;
+
+  public:
+    MovePicker(const Search& search, const Position& position);
+
+    auto next() -> Move;
+
+  private:
+    auto generate_moves() -> void;
+  };
+
+}  // namespace rose

--- a/src/rose/move_picker.hpp
+++ b/src/rose/move_picker.hpp
@@ -4,8 +4,6 @@
 #include "rose/move.hpp"
 #include "rose/movegen.hpp"
 
-#include <span>
-
 namespace rose {
 
   struct Search;
@@ -13,8 +11,9 @@ namespace rose {
   struct MovePicker {
   private:
     enum class Stage {
-      generate_moves,
+      generate_noisy,
       emit_noisy,
+      generate_quiet,
       emit_quiet,
       end,
     };
@@ -23,15 +22,14 @@ namespace rose {
       return m_stage == Stage::emit_quiet;
     }
 
-    Stage m_stage = Stage::generate_moves;
+    Stage m_stage = Stage::generate_noisy;
 
     const Search& m_search;
     const Position& m_position;
+    MoveGen m_movegen;
 
     usize m_current_index = 0;
     MoveList m_moves;
-    std::span<Move> m_noisy;
-    std::span<Move> m_quiet;
 
   public:
     MovePicker(const Search& search, const Position& position);
@@ -39,7 +37,8 @@ namespace rose {
     auto next() -> Move;
 
   private:
-    auto generate_moves() -> void;
+    auto generate_noisy() -> void;
+    auto generate_quiet() -> void;
   };
 
 }  // namespace rose

--- a/src/rose/movegen.cpp
+++ b/src/rose/movegen.cpp
@@ -100,15 +100,13 @@ namespace rose {
     }
   }
 
-  template<bool in_check>
+  template<bool in_check, MoveGen::Mode mode>
   auto MoveGen::generate_moves_to(MoveList& moves, Square king_sq, Bitboard valid_destinations, PieceType one_checker) -> void {
     const Position& position = m_position;
     const Color stm = position.stm();
 
     const Bitboard empty = position.board().empty_bitboard();
     const Bitboard enemy = position.board().color_bitboard(!stm);
-
-    const auto [at, pinned_bb] = position.calc_pin_info();
 
     const PieceMask king_mask = PieceMask::king();
     const PieceMask pawn_mask = position.piece_mask_for<PieceType::p>(stm);
@@ -123,96 +121,102 @@ namespace rose {
 
     const u16x16 srcs = position.piece_list_sq(stm).to_vector().convert<u16>();
 
-    // Capture-with-promotion
-    write_cap_promo(moves, at, pawn_active & enemy & pawn_info.promo_zone, pawn_mask);
-    // En passant
-    if (const Square ep = position.enpassant(); ep.is_valid() && (!in_check || one_checker == PieceType::p)) {
-      const PieceMask attackers = at[ep.raw] & pawn_mask;
-      if (!attackers.is_empty()) {
-        const Square victim = Square::from_file_and_rank(ep.file(), stm == Color::white ? 4 : 3);
-        if (attackers.popcount() > 1 || victim.rank() != king_sq.rank() || [&] {
-              // Detect clearance pins
-              const Square my_pawn = position.piece_list_sq(stm)[attackers.lsb()];
-              const int direction = victim.file() < king_sq.file() ? -1 : 1;
-              for (Square test_sq {static_cast<u8>(king_sq.raw + direction)}; test_sq.rank() == king_sq.rank(); test_sq.raw += direction) {
-                const Place p = position.board()[test_sq];
-                if (p.is_empty() || test_sq == victim || test_sq == my_pawn)
-                  continue;
-                return p.color() == stm || (p.ptype() != PieceType::r && p.ptype() != PieceType::q);
-              }
-              return true;
-            }()) {
-          const u16x16 dest = u16x16::splat(static_cast<u16>(MoveFlags::enpassant) | (static_cast<u16>(ep.raw) << 6));
-          moves.write(attackers.raw, srcs | dest);
+    if constexpr (mode == Mode::all || mode == Mode::noisy) {
+      // Capture-with-promotion
+      write_cap_promo(moves, m_at, pawn_active & enemy & pawn_info.promo_zone, pawn_mask);
+      // En passant
+      if (const Square ep = position.enpassant(); ep.is_valid() && (!in_check || one_checker == PieceType::p)) {
+        const PieceMask attackers = m_at[ep.raw] & pawn_mask;
+        if (!attackers.is_empty()) {
+          const Square victim = Square::from_file_and_rank(ep.file(), stm == Color::white ? 4 : 3);
+          if (attackers.popcount() > 1 || victim.rank() != king_sq.rank() || [&] {
+                // Detect clearance pins
+                const Square my_pawn = position.piece_list_sq(stm)[attackers.lsb()];
+                const int direction = victim.file() < king_sq.file() ? -1 : 1;
+                for (Square test_sq {static_cast<u8>(king_sq.raw + direction)}; test_sq.rank() == king_sq.rank(); test_sq.raw += direction) {
+                  const Place p = position.board()[test_sq];
+                  if (p.is_empty() || test_sq == victim || test_sq == my_pawn)
+                    continue;
+                  return p.color() == stm || (p.ptype() != PieceType::r && p.ptype() != PieceType::q);
+                }
+                return true;
+              }()) {
+            const u16x16 dest = u16x16::splat(static_cast<u16>(MoveFlags::enpassant) | (static_cast<u16>(ep.raw) << 6));
+            moves.write(attackers.raw, srcs | dest);
+          }
         }
       }
+      // Pawn captures
+      write_moves<MoveFlags::cap_normal>(moves, m_at, srcs, pawn_active & enemy & pawn_info.non_promo_dest, pawn_mask);
+      // Non-pawn captures
+      write_moves<MoveFlags::cap_normal>(moves, m_at, srcs, nonpawn_active & enemy, nonpawn_mask);
+      // King captures
+      if constexpr (!in_check)
+        write_moves<MoveFlags::cap_normal>(moves, m_at, srcs, king_active & enemy & ~danger, king_mask);
     }
-    // Pawn captures
-    write_moves<MoveFlags::cap_normal>(moves, at, srcs, pawn_active & enemy & pawn_info.non_promo_dest, pawn_mask);
-    // Non-pawn captures
-    write_moves<MoveFlags::cap_normal>(moves, at, srcs, nonpawn_active & enemy, nonpawn_mask);
-    // King captures
-    if constexpr (!in_check)
-      write_moves<MoveFlags::cap_normal>(moves, at, srcs, king_active & enemy & ~danger, king_mask);
-    // Castling
-    if constexpr (!in_check) {
-      const Square rook_hside = position.rook_info().hside(stm);
-      const Square rook_aside = position.rook_info().aside(stm);
 
-      const auto do_castle = [&](Square king_sq, Square rook_sq, i8 rook_dest, i8 king_dest, MoveFlags mf) {
-        rose_assert(position.board()[rook_sq].ptype() == PieceType::r && position.board()[rook_sq].color() == stm);
-        const Bitboard king_bb = king_sq.to_bitboard();
-        const Bitboard rook_bb = rook_sq.to_bitboard();
-        const Bitboard rook_ray = backrank_ray(rook_sq, Square::from_file_and_rank(rook_dest, king_sq.rank()));
-        const Bitboard king_ray = backrank_ray(king_sq, Square::from_file_and_rank(king_dest, king_sq.rank()));
-        const Bitboard clear = empty | king_bb | rook_bb;
-        if ((~clear & rook_ray).is_empty() && ((~clear | danger) & king_ray).is_empty() && (rook_bb & pinned_bb).is_empty()) {
-          moves.push_back(Move::make(king_sq, rook_sq, mf));
+    if constexpr (mode == Mode::all || mode == Mode::quiet) {
+      // Castling
+      if constexpr (!in_check) {
+        const Square rook_hside = position.rook_info().hside(stm);
+        const Square rook_aside = position.rook_info().aside(stm);
+
+        const auto do_castle = [&](Square king_sq, Square rook_sq, i8 rook_dest, i8 king_dest, MoveFlags mf) {
+          rose_assert(position.board()[rook_sq].ptype() == PieceType::r && position.board()[rook_sq].color() == stm);
+          const Bitboard king_bb = king_sq.to_bitboard();
+          const Bitboard rook_bb = rook_sq.to_bitboard();
+          const Bitboard rook_ray = backrank_ray(rook_sq, Square::from_file_and_rank(rook_dest, king_sq.rank()));
+          const Bitboard king_ray = backrank_ray(king_sq, Square::from_file_and_rank(king_dest, king_sq.rank()));
+          const Bitboard clear = empty | king_bb | rook_bb;
+          if ((~clear & rook_ray).is_empty() && ((~clear | danger) & king_ray).is_empty() && (rook_bb & m_pinned).is_empty()) {
+            moves.push_back(Move::make(king_sq, rook_sq, mf));
+          }
+        };
+
+        if (rook_aside.is_valid())
+          do_castle(king_sq, rook_aside, 3, 2, MoveFlags::castle_aside);
+        if (rook_hside.is_valid())
+          do_castle(king_sq, rook_hside, 5, 6, MoveFlags::castle_hside);
+      }
+      // Non-pawn quiets
+      write_moves<MoveFlags::normal>(moves, m_at, srcs, nonpawn_active & empty, nonpawn_mask);
+      // King quiets
+      if constexpr (!in_check)
+        write_moves<MoveFlags::normal>(moves, m_at, srcs, king_active & empty & ~danger, king_mask);
+      // Do pawns
+      {
+        const Bitboard pinned_pawns = m_pinned & ~Bitboard::file_mask(king_sq.file());
+
+        const Bitboard bb = position.bitboard_for<PieceType::p>(stm) & ~pinned_pawns;
+        const auto pawn_empty = pawns::pawn_destination_empty(stm, empty, valid_destinations);
+        const auto pawn_moves = pawns::pawn_moves(stm);
+
+        const Bitboard pawn_normal = bb & pawn_empty.normal_move;
+        const Bitboard pawn_double = bb & pawn_empty.double_move;
+
+        // Promotions
+        {
+          const u8 mask = static_cast<u8>(pawn_normal.raw >> pawn_info.promotable_shift);
+          moves.write4(mask, pawn_moves.promotions);
         }
-      };
-
-      if (rook_aside.is_valid())
-        do_castle(king_sq, rook_aside, 3, 2, MoveFlags::castle_aside);
-      if (rook_hside.is_valid())
-        do_castle(king_sq, rook_hside, 5, 6, MoveFlags::castle_hside);
-    }
-    // Non-pawn quiets
-    write_moves<MoveFlags::normal>(moves, at, srcs, nonpawn_active & empty, nonpawn_mask);
-    // King quiets
-    if constexpr (!in_check)
-      write_moves<MoveFlags::normal>(moves, at, srcs, king_active & empty & ~danger, king_mask);
-    // Do pawns
-    {
-      const Bitboard pinned_pawns = pinned_bb & ~Bitboard::file_mask(king_sq.file());
-
-      const Bitboard bb = position.bitboard_for<PieceType::p>(stm) & ~pinned_pawns;
-      const auto pawn_empty = pawns::pawn_destination_empty(stm, empty, valid_destinations);
-      const auto pawn_moves = pawns::pawn_moves(stm);
-
-      const Bitboard pawn_normal = bb & pawn_empty.normal_move;
-      const Bitboard pawn_double = bb & pawn_empty.double_move;
-
-      // Promotions
-      {
-        const u8 mask = static_cast<u8>(pawn_normal.raw >> pawn_info.promotable_shift);
-        moves.write4(mask, pawn_moves.promotions);
-      }
-      // Relative rank 3-6
-      {
-        constexpr int normal_shift = 16;
-        const u32 mask = static_cast<u32>(pawn_normal.raw >> normal_shift);
-        moves.write(mask, pawn_moves.normal_moves);
-      }
-      // Relative rank 2
-      {
-        const u8 normal_mask = static_cast<u8>(pawn_normal.raw >> pawn_info.second_rank_shift);
-        const u8 double_mask = static_cast<u8>(pawn_double.raw >> pawn_info.second_rank_shift);
-        const u16 mask = (static_cast<u16>(double_mask) << 8) | normal_mask;
-        moves.write(mask, pawn_moves.double_moves);
+        // Relative rank 3-6
+        {
+          constexpr int normal_shift = 16;
+          const u32 mask = static_cast<u32>(pawn_normal.raw >> normal_shift);
+          moves.write(mask, pawn_moves.normal_moves);
+        }
+        // Relative rank 2
+        {
+          const u8 normal_mask = static_cast<u8>(pawn_normal.raw >> pawn_info.second_rank_shift);
+          const u8 double_mask = static_cast<u8>(pawn_double.raw >> pawn_info.second_rank_shift);
+          const u16 mask = (static_cast<u16>(double_mask) << 8) | normal_mask;
+          moves.write(mask, pawn_moves.double_moves);
+        }
       }
     }
   }
 
+  template<MoveGen::Mode mode>
   auto MoveGen::generate_king_moves_with_checkers(MoveList& moves, Square king_sq, PieceMask checkers) -> void {
     const Color stm = m_position.stm();
 
@@ -238,42 +242,56 @@ namespace rose {
     const Bitboard active = m_position.attack_table(stm).bitboard_for(king_mask) & valid_destinations;
     const Bitboard danger = m_position.attack_table(!stm).bitboard_any();
 
-    write_moves<MoveFlags::cap_normal>(moves, king_sq, active & enemy & ~danger);
-    write_moves<MoveFlags::normal>(moves, king_sq, active & empty & ~danger);
+    if constexpr (mode == Mode::all || mode == Mode::noisy)
+      write_moves<MoveFlags::cap_normal>(moves, king_sq, active & enemy & ~danger);
+    if constexpr (mode == Mode::all || mode == Mode::quiet)
+      write_moves<MoveFlags::normal>(moves, king_sq, active & empty & ~danger);
   }
 
+  template<MoveGen::Mode mode>
   auto MoveGen::generate_moves_no_checkers(MoveList& moves, Square king_sq) -> void {
-    generate_moves_to<false>(moves, king_sq, ~Bitboard {}, PieceType::none);
+    generate_moves_to<false, mode>(moves, king_sq, ~Bitboard {}, PieceType::none);
   }
 
+  template<MoveGen::Mode mode>
   auto MoveGen::generate_moves_one_checker(MoveList& moves, Square king_sq, PieceMask checkers) -> void {
     const PieceType checker_ptype = m_position.piece_list_type(!m_position.stm())[checkers.lsb()];
     const Square checker_sq = m_position.piece_list_sq(!m_position.stm())[checkers.lsb()];
     const Bitboard valid_destinations = checker_ptype == PieceType::n ? checker_sq.to_bitboard() : rays::calc_ray_to(king_sq, checker_sq);
-    generate_moves_to<true>(moves, king_sq, valid_destinations, checker_ptype);
-    generate_king_moves_with_checkers(moves, king_sq, checkers);
+    generate_moves_to<true, mode>(moves, king_sq, valid_destinations, checker_ptype);
+    generate_king_moves_with_checkers<mode>(moves, king_sq, checkers);
   }
 
+  template<MoveGen::Mode mode>
   auto MoveGen::generate_moves_two_checkers(MoveList& moves, Square king_sq, PieceMask checkers) -> void {
-    generate_king_moves_with_checkers(moves, king_sq, checkers);
+    generate_king_moves_with_checkers<mode>(moves, king_sq, checkers);
   }
 
   MoveGen::MoveGen(const Position& position) :
       m_position(position) {
   }
 
+  auto MoveGen::prepare() -> void {
+    std::tie(m_at, m_pinned) = m_position.calc_pin_info();
+  }
+
+  template<MoveGen::Mode mode>
   auto MoveGen::generate_moves(MoveList& moves) -> void {
     const Color stm = m_position.stm();
     const Square king_sq = m_position.king_sq(stm);
     const PieceMask checkers = m_position.attack_table(!stm).read(king_sq);
     switch (checkers.popcount()) {
     case 0:
-      return generate_moves_no_checkers(moves, king_sq);
+      return generate_moves_no_checkers<mode>(moves, king_sq);
     case 1:
-      return generate_moves_one_checker(moves, king_sq, checkers);
+      return generate_moves_one_checker<mode>(moves, king_sq, checkers);
     default:
-      return generate_moves_two_checkers(moves, king_sq, checkers);
+      return generate_moves_two_checkers<mode>(moves, king_sq, checkers);
     }
   }
+
+  template auto MoveGen::generate_moves<MoveGen::Mode::all>(MoveList& moves) -> void;
+  template auto MoveGen::generate_moves<MoveGen::Mode::noisy>(MoveList& moves) -> void;
+  template auto MoveGen::generate_moves<MoveGen::Mode::quiet>(MoveList& moves) -> void;
 
 }  // namespace rose

--- a/src/rose/movegen.hpp
+++ b/src/rose/movegen.hpp
@@ -22,6 +22,14 @@ namespace rose {
   struct MoveGen {
   private:
     const Position& m_position;
+    std::array<PieceMask, 64> m_at;
+    Bitboard m_pinned;
+
+    enum class Mode {
+      all,
+      noisy,
+      quiet,
+    };
 
     template<MoveFlags mf>
     auto write_moves(MoveList& moves, const std::array<PieceMask, 64>& at, u16x16 srcs, Bitboard bb, PieceMask pm) -> void;
@@ -29,18 +37,45 @@ namespace rose {
     auto write_moves(MoveList& moves, Square from, Bitboard to_bb) -> void;
     auto write_cap_promo(MoveList& moves, const std::array<PieceMask, 64>& at, Bitboard bb, PieceMask pm) -> void;
 
-    template<bool in_check>
+    template<bool in_check, Mode mode>
     auto generate_moves_to(MoveList& moves, Square king_sq, Bitboard valid_destinations, PieceType one_checker) -> void;
+    template<Mode mode>
     auto generate_king_moves_with_checkers(MoveList& moves, Square king_sq, PieceMask checkers) -> void;
 
+    template<Mode mode>
     auto generate_moves_no_checkers(MoveList& moves, Square king_sq) -> void;
+    template<Mode mode>
     auto generate_moves_one_checker(MoveList& moves, Square king_sq, PieceMask checkers) -> void;
+    template<Mode mode>
     auto generate_moves_two_checkers(MoveList& moves, Square king_sq, PieceMask checkers) -> void;
+
+    template<Mode mode>
+    auto generate_moves(MoveList& moves) -> void;
 
   public:
     explicit MoveGen(const Position& position);
 
-    auto generate_moves(MoveList& moves) -> void;
+    auto prepare() -> void;
+
+    auto generate_all(MoveList& moves) -> void {
+      generate_moves<Mode::all>(moves);
+    }
+
+    auto generate_noisy(MoveList& moves) -> void {
+      generate_moves<Mode::noisy>(moves);
+    }
+
+    auto generate_quiet(MoveList& moves) -> void {
+      generate_moves<Mode::quiet>(moves);
+    }
   };
+
+  inline auto generate_all_moves(const Position& position) -> MoveList {
+    MoveList moves;
+    MoveGen movegen {position};
+    movegen.prepare();
+    movegen.generate_all(moves);
+    return moves;
+  }
 
 }  // namespace rose

--- a/src/rose/position.cpp
+++ b/src/rose/position.cpp
@@ -181,9 +181,7 @@ namespace rose {
   }
 
   auto Position::has_no_legal_moves_slow() const -> bool {
-    MoveList moves;
-    MoveGen movegen {*this};
-    movegen.generate_moves(moves);
+    const MoveList moves = generate_all_moves(*this);
     return moves.size() == 0;
   }
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -3,6 +3,7 @@
 #include "rose/common.hpp"
 #include "rose/engine_output.hpp"
 #include "rose/game.hpp"
+#include "rose/move_picker.hpp"
 #include "rose/movegen.hpp"
 #include "rose/score.hpp"
 #include "rose/search_control.hpp"
@@ -210,13 +211,11 @@ namespace rose {
     if (depth <= 0 || ply >= max_depth)
       return eval(position);
 
-    MoveList moves;
-    MoveGen movegen {position};
-    movegen.generate_moves(moves);
+    MovePicker moves {*this, position};
 
     Score best_score = score::none;
 
-    for (Move m : moves) {
+    for (Move m = moves.next(); m.is_some(); m = moves.next()) {
       const Position child_position = position.move(m);
 
       Line child_pv {};

--- a/tests/test_movegen.cpp
+++ b/tests/test_movegen.cpp
@@ -30,9 +30,7 @@ auto double_check() -> void {
     for (const auto m : should_movelist)
       should_moves.emplace(Move::parse(m, MoveFormat::frc, position).value());
 
-    MoveList got_movelist;
-    MoveGen movegen {position};
-    movegen.generate_moves(got_movelist);
+    const MoveList got_movelist = generate_all_moves(position);
 
     std::unordered_set<Move> got_moves;
     for (const auto m : got_movelist) {


### PR DESCRIPTION
This is tested as a non-regression as the move generator already generates noisy moves before quiet moves.

STC non-reg
Elo   | 0.07 +- 0.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 25158 W: 630 L: 625 D: 23903
Penta | [6, 398, 11763, 409, 3]

Bench: 2673124