### PR TITLE
Add CECP (XBoard) support

### DIFF
--- a/src/rose/engine_output_null.hpp
+++ b/src/rose/engine_output_null.hpp
@@ -9,11 +9,11 @@ namespace rose {
   struct EngineOutputNull : public EngineOutput {
     virtual ~EngineOutputNull() = default;
 
-    virtual auto info(EngineOutput::Info args) -> void override {
+    auto info(EngineOutput::Info args) -> void override {
       rose_unused(args);
     }
 
-    virtual auto bestmove(Move m) -> void override {
+    auto bestmove(Move m) -> void override {
       rose_unused(m);
     }
   };

--- a/src/rose/engine_output_xboard.hpp
+++ b/src/rose/engine_output_xboard.hpp
@@ -9,31 +9,33 @@
 
 namespace rose {
 
-  struct EngineOutputUci : public EngineOutput {
+  template<class Interface>
+  struct EngineOutputXboard : public EngineOutput {
   private:
     MoveFormat format;
+    Interface& interface;
 
   public:
-    EngineOutputUci(MoveFormat format) :
+    EngineOutputXboard(Interface& interface, MoveFormat format) :
+        interface(interface),
         format(format) {
     }
 
-    virtual ~EngineOutputUci() = default;
+    virtual ~EngineOutputXboard() = default;
 
     auto info(EngineOutput::Info args) -> void override {
-      const auto time_ms = time::cast<time::Milliseconds>(args.time);
-      const u64 nps = time::nps<u64>(args.nodes, args.time);
-      fmt::print("info depth {} score cp {} time {} nodes {} nps {} pv {}\n",
+      const auto time_cs = time::cast<time::Centiseconds>(args.time);
+      fmt::print("{}\t{}\t{}\t{}\t{}\n",
                  args.depth,
                  args.score,
-                 time_ms.count(),
+                 time_cs.count(),  // centiseconds
                  args.nodes,
-                 nps,
                  args.pv.to_string(format));
     }
 
     auto bestmove(Move m) -> void override {
-      fmt::print("bestmove {}\n", m.to_string(format));
+      interface.xboard_engine_moved(m);
+      fmt::print("move {}\n", m.to_string(format));
       std::fflush(stdout);
     }
   };

--- a/src/rose/interface.cpp
+++ b/src/rose/interface.cpp
@@ -1,9 +1,11 @@
 #include "rose/interface.hpp"
 
+#include "fmt/base.h"
 #include "rose/cmd/bench.hpp"
 #include "rose/cmd/perft.hpp"
 #include "rose/common.hpp"
 #include "rose/engine_output_uci.hpp"
+#include "rose/engine_output_xboard.hpp"
 #include "rose/position.hpp"
 #include "rose/search.hpp"
 #include "rose/util/string.hpp"
@@ -11,21 +13,47 @@
 #include "rose/util/tokenizer.hpp"
 #include "rose/version.hpp"
 
+#include <atomic>
 #include <cstdio>
+#include <cstdlib>
 #include <fmt/format.h>
 #include <memory>
 #include <string_view>
 
 namespace rose {
 
+  static constexpr usize default_hash = 16;
+  static constexpr usize max_hash = 1048576;
+  static constexpr usize max_threads = 1024;
+
   auto Interface::set_format(MoveFormat format) -> void {
     m_format = format;
-    m_engine.set_output(std::make_shared<EngineOutputUci>(m_format));
+    switch (m_protocol) {
+    case Protocol::uci:
+      m_engine.set_output(std::make_shared<EngineOutputUci>(m_format));
+      break;
+    case Protocol::xboard:
+      m_engine.set_output(std::make_shared<EngineOutputXboard<Interface>>(*this, m_format));
+      break;
+    }
+  }
+
+  auto Interface::set_protocol(Protocol protocol) -> void {
+    m_protocol = protocol;
+    set_format(m_format);
   }
 
   template<typename... Args>
   auto Interface::print_protocol_error(std::string_view cmd, fmt::format_string<Args...> fmt, Args&&... args) -> void {
-    fmt::print("info error ({}): ", cmd);
+    switch (m_protocol) {
+    case Protocol::uci:
+      fmt::print("info error");
+      break;
+    case Protocol::xboard:
+      fmt::print("Error");
+      break;
+    }
+    fmt::print(" ({}): ", cmd);
     fmt::print(fmt, std::forward<Args>(args)...);
     fmt::print("\n");
     std::fflush(stdout);
@@ -36,7 +64,14 @@ namespace rose {
   }
 
   auto Interface::print_illegal_move(std::string_view move) -> void {
-    print_protocol_error("illegal move", "{}", move);
+    switch (m_protocol) {
+    case Protocol::uci:
+      print_protocol_error("illegal move", "{}", move);
+      break;
+    case Protocol::xboard:
+      fmt::print("Illegal move: {}\n", move);
+      break;
+    }
   }
 
   auto Interface::expect_token(std::string_view cmd, Tokenizer& it, std::string_view token) -> bool {
@@ -46,6 +81,51 @@ namespace rose {
     if (!next.empty()) [[unlikely]]
       print_unrecognised_token(cmd, next);
     return false;
+  }
+
+  auto Interface::uci_parse_command(std::string_view line, time::TimePoint start_time) -> void {
+    Tokenizer it {line};
+    const std::string_view cmd = it.next();
+
+    if (cmd == "position") {
+      uci_position(it);
+    } else if (cmd == "go") {
+      uci_go(it, start_time);
+    } else if (cmd == "ucinewgame") {
+      uci_ucinewgame(it);
+    } else if (cmd == "uci") {
+      uci_uci(it);
+    } else if (cmd == "isready") {
+      uci_isready(it);
+    } else if (cmd == "setoption") {
+      uci_setoption(it);
+    } else if (cmd == "stop") {
+      uci_stop(it);
+    } else if (cmd == "perft") {
+      uci_perft(it);
+    } else if (cmd == "bench") {
+      uci_bench(it);
+    } else if (cmd == "moves") {
+      uci_moves(it);
+    } else if (cmd == "d") {
+      cmd_d(it);
+    } else if (cmd == "getposition") {
+      m_game.print_game_record();
+    } else if (cmd == "dumpposition") {
+      m_game.position().dump();
+    } else if (cmd == "hashstack") {
+      m_game.print_hash_stack();
+    } else if (cmd == "wait") {
+      m_engine.wait();
+    } else if (cmd == "quit") {
+      std::exit(0);
+    } else if (cmd == "xboard") {
+      set_protocol(Protocol::xboard);
+      fmt::print("\n");
+      std::fflush(stdout);
+    } else {
+      print_protocol_error(cmd, "unknown command");
+    }
   }
 
   auto Interface::uci_position(Tokenizer& it) -> void {
@@ -127,8 +207,8 @@ namespace rose {
   auto Interface::uci_uci(Tokenizer&) -> void {
     fmt::print("id name Rose {}\n", rose::version::to_string());
     fmt::print("id author 87 (87flowers.com)\n");
-    fmt::print("option name Hash type spin default 16 min 1 max 1048576\n");
-    fmt::print("option name Threads type spin default 1 min 1 max 1024\n");
+    fmt::print("option name Hash type spin default {} min 1 max {}\n", default_hash, max_hash);
+    fmt::print("option name Threads type spin default 1 min 1 max {}\n", max_threads);
     fmt::print("option name UCI_Chess960 type check default false\n");
     fmt::print("uciok\n");
   }
@@ -207,7 +287,280 @@ namespace rose {
     }
   }
 
-  auto Interface::uci_d(Tokenizer&) -> void {
+  auto Interface::xboard_parse_command(std::string_view line, time::TimePoint start_time) -> void {
+    Tokenizer it {line};
+    const std::string_view cmd = it.next();
+
+    if (cmd == "protover") {
+      xboard_protover(it);
+    } else if (cmd == "accepted" || cmd == "rejected") {
+      // ignore
+    } else if (cmd == "new") {
+      xboard_new(it);
+    } else if (cmd == "variant") {
+      xboard_variant(it);
+    } else if (cmd == "quit") {
+      std::exit(0);
+    } else if (cmd == "random") {
+      // ignore
+    } else if (cmd == "force") {
+      xboard_force(it);
+    } else if (cmd == "go") {
+      xboard_go(start_time);
+    } else if (cmd == "level") {
+      xboard_level(it);
+    } else if (cmd == "st") {
+      xboard_st(it);
+    } else if (cmd == "sd") {
+      xboard_sd(it);
+    } else if (cmd == "time") {
+      xboard_time(it);
+    } else if (cmd == "otim") {
+      xboard_otim(it);
+    } else if (cmd == "usermove") {
+      xboard_usermove(it.next(), start_time);
+    } else if (cmd == "?") {
+      m_engine.stop();
+    } else if (cmd == "ping") {
+      xboard_ping(it);
+    } else if (cmd == "result") {
+      m_engine.stop();
+    } else if (cmd == "setboard") {
+      xboard_setboard(it);
+    } else if (cmd == "undo") {
+      xboard_undo(it);
+    } else if (cmd == "memory") {
+      xboard_memory(it);
+    } else if (cmd == "cores") {
+      xboard_cores(it);
+    } else if (cmd == "d") {
+      cmd_d(it);
+    } else if (cmd == "getposition") {
+      m_game.print_game_record();
+    } else if (cmd == "dumpposition") {
+      m_game.position().dump();
+    } else if (cmd == "hashstack") {
+      m_game.print_hash_stack();
+    } else if (cmd == "wait") {
+      m_engine.wait();
+    } else if (cmd == "uci") {
+      set_protocol(Protocol::uci);
+      uci_uci(it);
+    } else if (cmd == "O-O" || cmd == "O-O-O" || std::find_if(cmd.begin(), cmd.end(), [](char ch) {
+                                                   return ch >= '0' && ch <= '9';
+                                                 }) != cmd.end()) {
+      xboard_usermove(cmd, start_time);
+    } else {
+      print_protocol_error(cmd, "unknown command");
+    }
+  }
+
+  auto Interface::xboard_engine_moved(Move m) -> void {
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    m_game.move(m);
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+  }
+
+  auto Interface::xboard_protover(Tokenizer&) -> void {
+    fmt::print("feature myname=\"Rose {}\"\n", rose::version::to_string());
+    fmt::print("feature variants=\"normal,fischerandom\"\n");
+    fmt::print("feature sigint=0 sigterm=0 ping=1 debug=1\n");
+    fmt::print("feature colors=0 setboard=1 san=0\n");
+    fmt::print("feature draw=0 analyze=0\n");
+    fmt::print("feature memory=1 smp=1\n");
+
+    // UCI-isms
+    fmt::print("feature option=\"Hash -spin {} 1 {}\"\n", default_hash, max_hash);
+    fmt::print("feature option=\"Threads -spin 1 1 {}\"\n", max_threads);
+
+    fmt::print("feature done=1\n");
+  }
+
+  auto Interface::xboard_new(Tokenizer&) -> void {
+    m_engine.reset();
+    m_game.reset();
+    set_format(MoveFormat::classical);
+    m_xboard.force = false;
+    m_xboard.tc_sd = std::nullopt;
+    if (m_xboard.tc_base) {
+      m_xboard.clocks[0] = *m_xboard.tc_base;
+      m_xboard.clocks[1] = *m_xboard.tc_base;
+    }
+  }
+
+  auto Interface::xboard_variant(Tokenizer& it) -> void {
+    const std::string_view variant = it.next();
+
+    if (variant == "normal") {
+      set_format(MoveFormat::classical);
+    } else if (variant == "fischerandom") {
+      set_format(MoveFormat::frc);
+    } else {
+      print_unrecognised_token("variant", variant);
+    }
+  }
+
+  auto Interface::xboard_force(Tokenizer&) -> void {
+    m_xboard.force = true;
+  }
+
+  auto Interface::xboard_go(time::TimePoint start_time) -> void {
+    m_xboard.force = false;
+
+    SearchLimit limits;
+
+    limits.has_time = true;
+    if (m_xboard.tc_st) {
+      limits.movetime = time::cast<time::Milliseconds>(*m_xboard.tc_st).count();
+    } else {
+      limits.wtime = time::cast<time::Milliseconds>(m_xboard.clocks[0]).count();
+      limits.btime = time::cast<time::Milliseconds>(m_xboard.clocks[1]).count();
+      if (m_xboard.tc_increment) {
+        limits.winc = time::cast<time::Milliseconds>(*m_xboard.tc_increment).count();
+        limits.binc = time::cast<time::Milliseconds>(*m_xboard.tc_increment).count();
+      }
+    }
+
+    if (m_xboard.tc_sd) {
+      limits.has_other = true;
+      limits.depth = m_xboard.tc_sd;
+    }
+
+    m_engine.run_search(start_time, limits, m_game);
+  }
+
+  auto Interface::xboard_level(Tokenizer& it) -> void {
+    const std::string_view mpt_str = it.next();
+    const std::string_view base_str = it.next();
+    const std::string_view inc_str = it.next();
+
+    if (mpt_str != "0") {
+      fmt::print("# Warning: Rose currently pretends repeating time control periods don't exist\n");
+    }
+
+    f64 base;
+    if (base_str.contains(':')) {
+      const auto split = string_split(std::string {base_str}, ':');
+      const auto mins = parse_f64(split[0]);
+      const auto secs = parse_f64(split[1]);
+      if (split.size() > 2 || !mins || !secs)
+        return print_protocol_error("level", "invalid base value: {}", base_str);
+      base = *mins * 60 + *secs;
+    } else {
+      const auto mins = parse_f64(base_str);
+      if (!mins)
+        return print_protocol_error("level", "invalid base value: {}", base_str);
+      base = *mins * 60;
+    }
+
+    const auto inc = parse_f64(inc_str);
+    if (!inc)
+      return print_protocol_error("level", "invalid inc value: {}", inc_str);
+
+    m_xboard.tc_base = time::cast<time::Duration>(time::FloatSeconds {base});
+    m_xboard.tc_increment = time::cast<time::Duration>(time::FloatSeconds {*inc});
+    m_xboard.tc_st = std::nullopt;
+  }
+
+  auto Interface::xboard_st(Tokenizer& it) -> void {
+    const std::string_view st_str = it.next();
+    const auto st = parse_f64(st_str);
+    if (!st)
+      return print_protocol_error("st", "invalid st value: {}", st_str);
+
+    m_xboard.tc_base = std::nullopt;
+    m_xboard.tc_increment = std::nullopt;
+    m_xboard.tc_st = time::cast<time::Duration>(time::FloatSeconds {*st});
+  }
+
+  auto Interface::xboard_sd(Tokenizer& it) -> void {
+    const std::string_view sd_str = it.next();
+    const auto sd = parse_int(sd_str);
+    if (!sd || *sd <= 0)
+      return print_protocol_error("sd", "invalid sd value: {}", sd_str);
+
+    m_xboard.tc_sd = sd;
+  }
+
+  auto Interface::xboard_time(Tokenizer& it) -> void {
+    const std::string_view value = it.next();
+    const auto time = parse_f64(value);
+    if (!time)
+      return print_protocol_error("time", "invalid value: {}", value);
+
+    m_xboard.clocks[m_game.position().stm().invert().to_index()] = time::cast<time::Duration>(time::FloatSeconds {*time});
+  }
+
+  auto Interface::xboard_otim(Tokenizer& it) -> void {
+    const std::string_view value = it.next();
+    const auto time = parse_f64(value);
+    if (!time)
+      return print_protocol_error("otim", "invalid value: {}", value);
+
+    m_xboard.clocks[m_game.position().stm().to_index()] = time::cast<time::Duration>(time::FloatSeconds {*time});
+  }
+
+  auto Interface::xboard_usermove(std::string_view move_str, time::TimePoint start_time) -> void {
+    const Position& pos = m_game.position();
+    const Move m = [&] {
+      const Color stm = pos.stm();
+      if (move_str == "O-O") {
+        return Move::make(pos.king_sq(stm), pos.rook_info().hside(stm), MoveFlags::castle_hside);
+      }
+      if (move_str == "O-O-O") {
+        return Move::make(pos.king_sq(stm), pos.rook_info().aside(stm), MoveFlags::castle_aside);
+      }
+      return Move::parse(move_str, m_format, pos).value_or(Move::none());
+    }();
+
+    if (m.is_none() || pos.is_legal_slow(m))
+      return print_illegal_move(move_str);
+
+    m_game.move(m);
+
+    if (!m_xboard.force)
+      xboard_go(start_time);
+  }
+
+  auto Interface::xboard_ping(Tokenizer& it) -> void {
+    fmt::print("pong {}\n", it.rest());
+  }
+
+  auto Interface::xboard_setboard(Tokenizer& it) -> void {
+    const auto pos = Position::parse(it.rest());
+    if (!pos)
+      return print_protocol_error("setboard", "invalid fen provided: {}", pos.error());
+
+    m_engine.wait();
+    m_game.set_position(pos.value());
+  }
+
+  auto Interface::xboard_undo(Tokenizer&) -> void {
+    m_engine.wait();
+    m_game.unmove();
+  }
+
+  auto Interface::xboard_memory(Tokenizer& it) -> void {
+    const std::string_view value = it.next();
+    const auto hash = parse_int(value);
+    if (!hash || *hash <= 0)
+      return print_unrecognised_token("memory", value);
+
+    m_engine.wait();
+    m_engine.set_hash_size(*hash);
+  }
+
+  auto Interface::xboard_cores(Tokenizer& it) -> void {
+    const std::string_view value = it.next();
+    const auto threads = parse_int(value);
+    if (!threads || *threads <= 0)
+      return print_unrecognised_token("cores", value);
+
+    m_engine.wait();
+    m_engine.set_thread_count(*threads);
+  }
+
+  auto Interface::cmd_d(Tokenizer&) -> void {
     const Position& pos = m_game.position();
 
     fmt::print("   +------------------------+\n");
@@ -236,43 +589,11 @@ namespace rose {
   auto Interface::parse_command(std::string_view line) -> void {
     const time::TimePoint start_time = time::Clock::now();
 
-    Tokenizer it {line};
-    const std::string_view cmd = it.next();
-
-    if (cmd == "position") {
-      uci_position(it);
-    } else if (cmd == "go") {
-      uci_go(it, start_time);
-    } else if (cmd == "ucinewgame") {
-      uci_ucinewgame(it);
-    } else if (cmd == "uci") {
-      uci_uci(it);
-    } else if (cmd == "isready") {
-      uci_isready(it);
-    } else if (cmd == "setoption") {
-      uci_setoption(it);
-    } else if (cmd == "stop") {
-      uci_stop(it);
-    } else if (cmd == "perft") {
-      uci_perft(it);
-    } else if (cmd == "bench") {
-      uci_bench(it);
-    } else if (cmd == "moves") {
-      uci_moves(it);
-    } else if (cmd == "d") {
-      uci_d(it);
-    } else if (cmd == "getposition") {
-      m_game.print_game_record();
-    } else if (cmd == "dumpposition") {
-      m_game.position().dump();
-    } else if (cmd == "hashstack") {
-      m_game.print_hash_stack();
-    } else if (cmd == "wait") {
-      m_engine.wait();
-    } else if (cmd == "quit") {
-      std::exit(0);
-    } else {
-      print_protocol_error(cmd, "unknown command");
+    switch (m_protocol) {
+    case Protocol::uci:
+      return uci_parse_command(line, start_time);
+    case Protocol::xboard:
+      return xboard_parse_command(line, start_time);
     }
   }
 

--- a/src/rose/interface.hpp
+++ b/src/rose/interface.hpp
@@ -2,10 +2,13 @@
 
 #include "rose/common.hpp"
 #include "rose/engine.hpp"
+#include "rose/engine_output_xboard.hpp"
 #include "rose/game.hpp"
 #include "rose/util/time.hpp"
 #include "rose/util/tokenizer.hpp"
+#include "rose/xboard.hpp"
 
+#include <array>
 #include <fmt/format.h>
 #include <string_view>
 
@@ -13,17 +16,28 @@ namespace rose {
 
   class Interface {
   private:
+    enum class Protocol {
+      uci,
+      xboard,
+    };
+
     Game m_game;
-    MoveFormat m_format = MoveFormat::classical;
     Engine m_engine;
+    MoveFormat m_format = MoveFormat::classical;
+    Protocol m_protocol = Protocol::uci;
+
+    XBoardState m_xboard;
 
     auto set_format(MoveFormat format) -> void;
+    auto set_protocol(Protocol protocol) -> void;
 
     template<typename... Args>
     auto print_protocol_error(std::string_view cmd, fmt::format_string<Args...> fmt, Args&&... args) -> void;
     auto print_unrecognised_token(std::string_view cmd, std::string_view token) -> void;
     auto print_illegal_move(std::string_view move) -> void;
     auto expect_token(std::string_view cmd, Tokenizer& it, std::string_view token) -> bool;
+
+    auto uci_parse_command(std::string_view line, time::TimePoint start_time) -> void;
 
     auto uci_position(Tokenizer& it) -> void;
     auto uci_go(Tokenizer& it, time::TimePoint start_time) -> void;
@@ -35,7 +49,30 @@ namespace rose {
     auto uci_perft(Tokenizer& it) -> void;
     auto uci_bench(Tokenizer& it) -> void;
     auto uci_moves(Tokenizer& it) -> void;
-    auto uci_d(Tokenizer& it) -> void;
+
+    auto xboard_parse_command(std::string_view line, time::TimePoint start_time) -> void;
+
+    friend struct EngineOutputXboard<Interface>;
+    auto xboard_engine_moved(Move m) -> void;
+
+    auto xboard_protover(Tokenizer& it) -> void;
+    auto xboard_variant(Tokenizer& it) -> void;
+    auto xboard_new(Tokenizer& it) -> void;
+    auto xboard_force(Tokenizer& it) -> void;
+    auto xboard_go(time::TimePoint start_time) -> void;
+    auto xboard_level(Tokenizer& it) -> void;
+    auto xboard_st(Tokenizer& it) -> void;
+    auto xboard_sd(Tokenizer& it) -> void;
+    auto xboard_time(Tokenizer& it) -> void;
+    auto xboard_otim(Tokenizer& it) -> void;
+    auto xboard_usermove(std::string_view move, time::TimePoint start_time) -> void;
+    auto xboard_ping(Tokenizer& it) -> void;
+    auto xboard_setboard(Tokenizer& it) -> void;
+    auto xboard_undo(Tokenizer& it) -> void;
+    auto xboard_memory(Tokenizer& it) -> void;
+    auto xboard_cores(Tokenizer& it) -> void;
+
+    auto cmd_d(Tokenizer& it) -> void;
 
   public:
     Interface();

--- a/src/rose/position.cpp
+++ b/src/rose/position.cpp
@@ -10,6 +10,7 @@
 #include "rose/square.hpp"
 #include "rose/util/string.hpp"
 
+#include <algorithm>
 #include <array>
 #include <fmt/format.h>
 #include <string_view>
@@ -178,6 +179,11 @@ namespace rose {
   auto Position::startpos() -> Position {
     static const Position startpos = Position::parse("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").value();
     return startpos;
+  }
+
+  auto Position::is_legal_slow(Move m) const -> bool {
+    const MoveList moves = generate_all_moves(*this);
+    return std::find(moves.begin(), moves.end(), m) != moves.end();
   }
 
   auto Position::has_no_legal_moves_slow() const -> bool {

--- a/src/rose/position.hpp
+++ b/src/rose/position.hpp
@@ -219,6 +219,7 @@ namespace rose {
       return !attack_table(!m_stm).read(king_sq(m_stm)).is_empty();
     }
 
+    auto is_legal_slow(Move m) const -> bool;
     auto has_no_legal_moves_slow() const -> bool;
     auto is_stalemate_slow() const -> bool;
     auto is_fifty_move_draw(i32 ply = 0) const -> std::optional<Score>;

--- a/src/rose/util/string.cpp
+++ b/src/rose/util/string.cpp
@@ -2,6 +2,7 @@
 
 #include "rose/common.hpp"
 
+#include <charconv>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -66,6 +67,14 @@ namespace rose {
 
   auto parse_u64(std::string_view str) -> std::optional<u64> {
     return parse_integer<u64>(str);
+  }
+
+  auto parse_f64(std::string_view str) -> std::optional<f64> {
+    f64 result;
+    const auto [ptr, ec] = std::from_chars(str.data(), str.data() + str.size(), result);
+    if (ec != std::errc {} || ptr != str.data() + str.size())
+      return std::nullopt;
+    return result;
   }
 
 }  // namespace rose

--- a/src/rose/util/string.hpp
+++ b/src/rose/util/string.hpp
@@ -16,4 +16,6 @@ namespace rose {
   auto parse_u32(std::string_view str) -> std::optional<u32>;
   auto parse_u64(std::string_view str) -> std::optional<u64>;
 
+  auto parse_f64(std::string_view str) -> std::optional<f64>;
+
 }  // namespace rose

--- a/src/rose/util/time.hpp
+++ b/src/rose/util/time.hpp
@@ -10,6 +10,7 @@ namespace rose::time {
   using TimePoint = std::chrono::time_point<Clock>;
   using Duration = TimePoint::duration;
   using FloatSeconds = std::chrono::duration<f64>;
+  using Centiseconds = std::chrono::duration<i64, std::centi>;
   using Milliseconds = std::chrono::duration<i64, std::milli>;
 
   template<typename T>

--- a/src/rose/xboard.hpp
+++ b/src/rose/xboard.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "rose/common.hpp"
+#include "rose/util/time.hpp"
+
+#include <array>
+#include <optional>
+
+namespace rose {
+
+  struct XBoardState {
+    bool force = true;
+
+    std::array<time::Duration, 2> clocks;
+
+    std::optional<i32> tc_sd;
+    std::optional<time::Duration> tc_st;
+    std::optional<time::Duration> tc_base;
+    std::optional<time::Duration> tc_increment;
+  };
+
+}  // namespace rose


### PR DESCRIPTION
Basic xboard support.

Some issues to deal with later:
* Repeated time control support
* Suppress `move` output where required
* Restrict commands usable while search is ongoing

UCI Fixed Games STC Sanity Check
Elo   | 3.29 +- 5.90 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=16MB
Games | N: 4016 W: 966 L: 928 D: 2122
Penta | [54, 370, 1121, 410, 53]

Bench: 4802763