### PR TITLE
No best move in upper bound node

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -253,11 +253,11 @@ namespace rose {
 
       if (score > best_score) {
         best_score = score;
-        best_move = mv;
         pv.write(mv, std::move(child_pv));
 
         if (score > alpha) {
           bound = tt::Bound::exact;
+          best_move = mv;
           alpha = score;
           if (score >= beta) {
             bound = tt::Bound::lower_bound;

--- a/src/rose/tt.cpp
+++ b/src/rose/tt.cpp
@@ -42,6 +42,9 @@ namespace rose::tt {
     const auto [index, fragment] = split_hash(m_count, hash);
     Entry& entry = m_table.get()[index];
 
+    if (entry.fragment() == fragment && lr.move.is_none())
+      lr.move = entry.move();
+
     entry = Entry {fragment, ply, lr};
   }
 


### PR DESCRIPTION
STC
Elo   | 11.89 +- 8.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 3714 W: 1373 L: 1246 D: 1095
Penta | [138, 324, 853, 357, 185]

Bench: 48804344