### PR TITLE
Transposition table cutoffs

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -251,6 +251,23 @@ namespace rose {
 
     const tt::LookupResult tte = tt_load(position, ply);
 
+    if constexpr (!Node::is_pv) {
+      if (tte.is_some() && tte.depth >= depth && [&] {
+            switch (tte.bound) {
+            case tt::Bound::none:
+              return false;
+            case tt::Bound::lower_bound:
+              return tte.score >= beta;
+            case tt::Bound::exact:
+              return true;
+            case tt::Bound::upper_bound:
+              return tte.score <= alpha;
+            }
+          }()) {
+        return tte.score;
+      }
+    }
+
     MovePicker moves {*this, position, tte.move};
 
     MoveList fail_low_quiets;

--- a/src/rose/tt.hpp
+++ b/src/rose/tt.hpp
@@ -27,6 +27,10 @@ namespace rose::tt {
     auto is_none() const -> bool {
       return bound == Bound::none;
     }
+
+    auto is_some() const -> bool {
+      return bound != Bound::none;
+    }
   };
 
   struct Entry {


### PR DESCRIPTION
STC
Elo   | 111.63 +- 24.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 618 W: 328 L: 136 D: 154
Penta | [16, 30, 93, 86, 84]

Bench: 27390075