### PR TITLE
Counter moves history

### DIFF
--- a/src/rose/history.hpp
+++ b/src/rose/history.hpp
@@ -37,4 +37,38 @@ namespace rose {
     }
   };
 
+  struct ContinuationHistorySubtable {
+  private:
+    constexpr static i32 entry_max = 8192;
+    multi_array<i16, Color::count, PieceType::count, Square::count> m_table {};
+
+  public:
+    auto reset() -> void {
+      m_table = {};
+    }
+
+    auto update(Color stm, PieceType ptype, Move mv, i32 bonus) -> void {
+      i16& entry = m_table[stm.to_index()][ptype.to_index()][mv.to().to_index()];
+      gravity_formula<entry_max>(entry, bonus);
+    }
+
+    auto get(Color stm, PieceType ptype, Move mv) const -> i32 {
+      return m_table[stm.to_index()][ptype.to_index()][mv.to().to_index()];
+    }
+  };
+
+  struct ContinuationHistory {
+  private:
+    multi_array<ContinuationHistorySubtable, Color::count, PieceType::count, Square::count> m_table {};
+
+  public:
+    auto reset() -> void {
+      m_table = {};
+    }
+
+    auto get_subtable(Color stm, PieceType ptype, Move mv) -> ContinuationHistorySubtable* {
+      return &m_table[stm.to_index()][ptype.to_index()][mv.to().to_index()];
+    }
+  };
+
 }  // namespace rose

--- a/src/rose/move_picker.cpp
+++ b/src/rose/move_picker.cpp
@@ -10,9 +10,10 @@
 
 namespace rose {
 
-  MovePicker::MovePicker(const Search& search, const Position& position, Move tt_move) :
+  MovePicker::MovePicker(const Search& search, const Position& position, const SearchStack* ss, Move tt_move) :
       m_search(search),
       m_position(position),
+      m_ss(ss),
       m_movegen(position),
       m_tt_move(tt_move) {
   }
@@ -121,7 +122,14 @@ namespace rose {
 
     for (isize i = 0; i < m_moves.size(); i++) {
       const Move mv = m_moves[i];
-      scores[i] = m_search.m_quiet_history.get(stm, mv) * 256 - i;
+      const PieceType ptype = m_position.place_at(mv.from()).ptype();
+
+      i32 score = 0;
+      score += m_search.m_quiet_history.get(stm, mv);
+      if (m_ss[-1].conthist)
+        score += m_ss[-1].conthist->get(stm, ptype, mv);
+
+      scores[i] = score * 256 - i;
     }
 
     std::ranges::sort(std::ranges::zip_view(m_moves, scores), [](auto&& a, auto&& b) {

--- a/src/rose/move_picker.hpp
+++ b/src/rose/move_picker.hpp
@@ -3,6 +3,7 @@
 #include "rose/common.hpp"
 #include "rose/move.hpp"
 #include "rose/movegen.hpp"
+#include "rose/search.hpp"
 
 namespace rose {
 
@@ -28,6 +29,7 @@ namespace rose {
 
     const Search& m_search;
     const Position& m_position;
+    const SearchStack* m_ss;
     MoveGen m_movegen;
     Move m_tt_move;
 
@@ -37,7 +39,7 @@ namespace rose {
     MoveList m_bad_noisies;
 
   public:
-    MovePicker(const Search& search, const Position& position, Move tt_move);
+    MovePicker(const Search& search, const Position& position, const SearchStack* ss, Move tt_move);
 
     auto next() -> Move;
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -87,6 +87,7 @@ namespace rose {
 
   auto Search::reset() -> void {
     m_quiet_history.reset();
+    m_continuation_history.reset();
   }
 
   auto Search::launch() -> void {

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -320,7 +320,7 @@ namespace rose {
       }
     }
 
-    MovePicker moves {*this, position, tte.move};
+    MovePicker moves {*this, position, ss, tte.move};
 
     MoveList fail_low_quiets;
     MoveList fail_low_noisies;
@@ -334,9 +334,9 @@ namespace rose {
       move_count++;
 
       const Position child_position = position.move(mv);
-      m_hash_stack.push_back(child_position.hash());
+      make_move(ss, child_position, mv);
       rose_defer {
-        m_hash_stack.pop_back();
+        unmake_move(ss);
       };
 
       const i32 new_depth = depth - 1;
@@ -407,10 +407,17 @@ namespace rose {
       const i32 quiet_bonus = 150 * depth - 75;
       const i32 quiet_malus = 75 * depth - 30;
 
+      const i32 cont_bonus = 150 * depth - 75;
+      const i32 cont_malus = 75 * depth - 30;
+
       if (!best_move.capture()) {
         m_quiet_history.update(stm, best_move, quiet_bonus);
+        if (ss[-1].conthist)
+          ss[-1].conthist->update(stm, position.place_at(best_move.from()).ptype(), best_move, cont_bonus);
         for (const Move quiet : fail_low_quiets) {
           m_quiet_history.update(stm, quiet, -quiet_malus);
+          if (ss[-1].conthist)
+            ss[-1].conthist->update(stm, position.place_at(quiet.from()).ptype(), quiet, -cont_malus);
         }
       }
     }
@@ -455,7 +462,7 @@ namespace rose {
     }
     alpha = std::max(alpha, static_eval);
 
-    MovePicker moves {*this, position, Move::none()};
+    MovePicker moves {*this, position, ss, Move::none()};
     moves.skip_quiet();
 
     Score best_score = static_eval;
@@ -464,9 +471,9 @@ namespace rose {
 
     for (Move mv = moves.next(); mv.is_some(); mv = moves.next()) {
       const Position child_position = position.move(mv);
-      m_hash_stack.push_back(child_position.hash());
+      make_move(ss, child_position, mv);
       rose_defer {
-        m_hash_stack.pop_back();
+        unmake_move(ss);
       };
 
       Line child_pv {};
@@ -506,6 +513,18 @@ namespace rose {
 
   auto Search::tt_store(const Position& position, i32 ply, tt::LookupResult lr) -> void {
     m_shared.transposition_table.store(position.hash(), ply, lr);
+  }
+
+  auto Search::make_move(SearchStack* ss, const Position& child_position, Move mv) -> void {
+    m_hash_stack.push_back(child_position.hash());
+    ss->move = mv;
+    ss->conthist = m_continuation_history.get_subtable(!child_position.stm(), child_position.place_at(mv.to()).ptype(), mv);
+  }
+
+  auto Search::unmake_move(SearchStack* ss) -> void {
+    m_hash_stack.pop_back();
+    ss->move = Move::none();
+    ss->conthist = nullptr;
   }
 
 }  // namespace rose

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -22,8 +22,6 @@
 
 namespace rose {
 
-  constexpr i32 max_depth = 250;
-
   namespace node {
     struct Root;
     struct Pv;
@@ -215,8 +213,10 @@ namespace rose {
       }
 
       while (true) {
+        m_search_stack = {};
+
         pv.clear();
-        score = search<node::Root>(ctrl, m_root, pv, alpha, beta, 0, depth);
+        score = search<node::Root>(ctrl, m_root, pv, alpha, beta, &m_search_stack[search_stack_offset], 0, depth);
 
         if (score <= alpha) {
           alpha = std::max(score - delta, -score::infinity);
@@ -255,9 +255,10 @@ namespace rose {
   }
 
   template<typename Node, typename Controls>
-  auto Search::search(const Controls& ctrl, const Position& position, Line& pv, Score alpha, Score beta, i32 ply, i32 depth) -> Score {
+  auto Search::search(const Controls& ctrl, const Position& position, Line& pv, Score alpha, Score beta, SearchStack* ss, i32 ply, i32 depth)
+    -> Score {
     if (depth <= 0)
-      return qsearch<Node>(ctrl, position, pv, alpha, beta, ply);
+      return qsearch<Node>(ctrl, position, pv, alpha, beta, ss, ply);
 
     stats().nodes.fetch_add(1, std::memory_order_relaxed);
     if (!Node::is_root && is_main_thread() && ctrl.check_hard_termination(stats())) [[unlikely]] {
@@ -312,7 +313,7 @@ namespace rose {
         const i32 r = 1 + depth / 2;
         const i32 margin = 128 + depth * 10;
         const i32 bound = beta + margin;
-        const i32 score = search<node::NonPv>(ctrl, position, pv, bound - 1, bound, ply, depth - r);
+        const i32 score = search<node::NonPv>(ctrl, position, pv, bound - 1, bound, ss, ply, depth - r);
         if (score >= bound) {
           return beta;
         }
@@ -338,6 +339,7 @@ namespace rose {
         m_hash_stack.pop_back();
       };
 
+      const i32 new_depth = depth - 1;
       Line child_pv {};
       Score score = score::none;
 
@@ -346,23 +348,23 @@ namespace rose {
         const i32 log2_depth = std::bit_width(static_cast<u32>(depth)) - 1;
         const i32 log2_move_count = std::bit_width(static_cast<u32>(move_count)) - 1;
 
-        i32 reduction = 3072 + 256 * log2_depth * log2_move_count;
+        i32 reduction = 2048 + 256 * log2_depth * log2_move_count;
 
-        const i32 lmr_depth = std::clamp(depth - reduction / 1024, 0, depth - 1);
+        const i32 lmr_depth = std::clamp(new_depth - reduction / 1024, 0, new_depth);
 
-        score = -search<node::NonPv>(ctrl, child_position, child_pv, -alpha - 1, -alpha, ply + 1, lmr_depth);
+        score = -search<node::NonPv>(ctrl, child_position, child_pv, -alpha - 1, -alpha, ss + 1, ply + 1, lmr_depth);
 
-        if (score > alpha && lmr_depth < depth - 1) {
-          score = -search<node::NonPv>(ctrl, child_position, child_pv, -alpha - 1, -alpha, ply + 1, depth - 1);
+        if (score > alpha && lmr_depth < new_depth) {
+          score = -search<node::NonPv>(ctrl, child_position, child_pv, -alpha - 1, -alpha, ss + 1, ply + 1, new_depth);
         }
       }
       // PVS Scout Search
       else if (!Node::is_pv || move_count > 1) {
-        score = -search<node::NonPv>(ctrl, child_position, child_pv, -alpha - 1, -alpha, ply + 1, depth - 1);
+        score = -search<node::NonPv>(ctrl, child_position, child_pv, -alpha - 1, -alpha, ss + 1, ply + 1, new_depth);
       }
       // PVS Full Window Search
       if (Node::is_pv && (move_count == 1 || score > alpha)) {
-        score = -search<node::Pv>(ctrl, child_position, child_pv, -beta, -alpha, ply + 1, depth - 1);
+        score = -search<node::Pv>(ctrl, child_position, child_pv, -beta, -alpha, ss + 1, ply + 1, new_depth);
       }
 
       if (m_shared.stopping)
@@ -426,7 +428,7 @@ namespace rose {
   }
 
   template<typename Node, typename Controls>
-  auto Search::qsearch(const Controls& ctrl, const Position& position, Line& pv, Score alpha, Score beta, i32 ply) -> Score {
+  auto Search::qsearch(const Controls& ctrl, const Position& position, Line& pv, Score alpha, Score beta, SearchStack* ss, i32 ply) -> Score {
     stats().nodes.fetch_add(1, std::memory_order_relaxed);
     if (!Node::is_root && is_main_thread() && ctrl.check_hard_termination(stats())) [[unlikely]] {
       m_shared.stop();
@@ -468,7 +470,7 @@ namespace rose {
       };
 
       Line child_pv {};
-      const Score score = -qsearch<typename Node::next>(ctrl, child_position, child_pv, -beta, -alpha, ply + 1);
+      const Score score = -qsearch<typename Node::next>(ctrl, child_position, child_pv, -beta, -alpha, ss + 1, ply + 1);
 
       if (m_shared.stopping)
         return 0;

--- a/src/rose/search.hpp
+++ b/src/rose/search.hpp
@@ -21,6 +21,8 @@
 
 namespace rose {
 
+  constexpr i32 max_depth = 250;
+
   struct SearchLimit {
     bool has_time = false;
     std::optional<int> wtime;
@@ -87,6 +89,8 @@ namespace rose {
     }
   };
 
+  struct SearchStack {};
+
   struct Search {
   private:
     friend struct MovePicker;
@@ -100,6 +104,10 @@ namespace rose {
     std::vector<Move> m_move_stack;
     std::vector<Hash> m_hash_stack;
     usize m_hash_waterline;
+
+    inline static constexpr usize search_stack_offset = 8;
+    inline static constexpr usize search_stack_safety = 8;
+    std::array<SearchStack, max_depth + search_stack_offset + search_stack_safety> m_search_stack;
 
     QuietHistory m_quiet_history;
 
@@ -127,9 +135,9 @@ namespace rose {
     auto search_root(const Controls& ctrl) -> void;
 
     template<typename Node, typename Controls>
-    auto search(const Controls& ctrl, const Position& position, Line& pv, Score alpha, Score beta, i32 ply, i32 depth) -> Score;
+    auto search(const Controls& ctrl, const Position& position, Line& pv, Score alpha, Score beta, SearchStack* ss, i32 ply, i32 depth) -> Score;
     template<typename Node, typename Controls>
-    auto qsearch(const Controls& ctrl, const Position& position, Line& pv, Score alpha, Score beta, i32 ply) -> Score;
+    auto qsearch(const Controls& ctrl, const Position& position, Line& pv, Score alpha, Score beta, SearchStack* ss, i32 ply) -> Score;
 
     auto eval(const Position& position) -> Score;
 

--- a/src/rose/search.hpp
+++ b/src/rose/search.hpp
@@ -89,7 +89,10 @@ namespace rose {
     }
   };
 
-  struct SearchStack {};
+  struct SearchStack {
+    Move move = Move::none();
+    ContinuationHistorySubtable* conthist = nullptr;
+  };
 
   struct Search {
   private:
@@ -110,6 +113,7 @@ namespace rose {
     std::array<SearchStack, max_depth + search_stack_offset + search_stack_safety> m_search_stack;
 
     QuietHistory m_quiet_history;
+    ContinuationHistory m_continuation_history;
 
   public:
     Search(int id, SearchShared& shared) :
@@ -143,6 +147,9 @@ namespace rose {
 
     auto tt_load(const Position& position, i32 ply) -> tt::LookupResult;
     auto tt_store(const Position& position, i32 ply, tt::LookupResult lr) -> void;
+
+    auto make_move(SearchStack* ss, const Position& child_position, Move mv) -> void;
+    auto unmake_move(SearchStack* ss) -> void;
   };
 
 }  // namespace rose


### PR DESCRIPTION
STC
Elo   | 5.66 +- 4.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11610 W: 3325 L: 3136 D: 5149
Penta | [254, 1386, 2399, 1449, 317]

LTC
Elo   | 14.83 +- 7.47 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3422 W: 946 L: 800 D: 1676
Penta | [64, 357, 742, 465, 83]

Bench: 4770118