### PR TITLE
Follow up history

### DIFF
--- a/src/rose/move_picker.cpp
+++ b/src/rose/move_picker.cpp
@@ -126,8 +126,9 @@ namespace rose {
 
       i32 score = 0;
       score += m_search.m_quiet_history.get(stm, mv);
-      if (m_ss[-1].conthist)
-        score += m_ss[-1].conthist->get(stm, ptype, mv);
+      for (i32 i : {1, 2})
+        if (m_ss[-i].conthist)
+          score += m_ss[-i].conthist->get(stm, ptype, mv);
 
       scores[i] = score * 256 - i;
     }

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -413,12 +413,14 @@ namespace rose {
 
       if (!best_move.capture()) {
         m_quiet_history.update(stm, best_move, quiet_bonus);
-        if (ss[-1].conthist)
-          ss[-1].conthist->update(stm, position.place_at(best_move.from()).ptype(), best_move, cont_bonus);
+        for (i32 i : {1, 2})
+          if (ss[-i].conthist)
+            ss[-i].conthist->update(stm, position.place_at(best_move.from()).ptype(), best_move, cont_bonus);
         for (const Move quiet : fail_low_quiets) {
           m_quiet_history.update(stm, quiet, -quiet_malus);
-          if (ss[-1].conthist)
-            ss[-1].conthist->update(stm, position.place_at(quiet.from()).ptype(), quiet, -cont_malus);
+          for (i32 i : {1, 2})
+            if (ss[-i].conthist)
+              ss[-i].conthist->update(stm, position.place_at(quiet.from()).ptype(), quiet, -cont_malus);
         }
       }
     }


### PR DESCRIPTION
STC
Elo   | 12.65 +- 6.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4120 W: 1182 L: 1032 D: 1906
Penta | [82, 440, 886, 550, 102]

LTC
Elo   | 17.22 +- 8.03 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2786 W: 779 L: 641 D: 1366
Penta | [40, 289, 621, 379, 64]

Bench: 4934298