### PR TITLE
LMP improving

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -302,6 +302,12 @@ namespace rose {
     const bool is_in_check = position.is_in_check();
 
     const i32 static_eval = is_in_check ? score::none : eval(position);
+    ss->static_eval = static_eval;
+
+    const bool improving = is_in_check                       ? false :
+                           ss[-2].static_eval != score::none ? static_eval > ss[-2].static_eval :
+                           ss[-4].static_eval != score::none ? static_eval > ss[-4].static_eval :
+                                                               false;
 
     if (!Node::is_pv && !is_in_check) {
       // Reverse Futility Pruning
@@ -334,7 +340,7 @@ namespace rose {
     for (Move mv = moves.next(); mv.is_some(); mv = moves.next()) {
       if (!score::is_loss(best_score) && !is_in_check) {
         // Late Move Pruning
-        if (!mv.capture() && move_count >= 4 + depth * depth) {
+        if (!mv.capture() && move_count >= 4 + depth * depth / (2 - improving)) {
           moves.skip_quiet();
           continue;
         }

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -340,7 +340,7 @@ namespace rose {
     for (Move mv = moves.next(); mv.is_some(); mv = moves.next()) {
       if (!score::is_loss(best_score) && !is_in_check) {
         // Late Move Pruning
-        if (!mv.capture() && move_count >= 4 + depth * depth / (2 - improving)) {
+        if (!mv.capture() && move_count >= (4 + depth * depth) / (2 - improving)) {
           moves.skip_quiet();
           continue;
         }

--- a/src/rose/search.hpp
+++ b/src/rose/search.hpp
@@ -91,6 +91,7 @@ namespace rose {
 
   struct SearchStack {
     Move move = Move::none();
+    Score static_eval = score::none;
     ContinuationHistorySubtable* conthist = nullptr;
   };
 


### PR DESCRIPTION
STC
Elo   | 23.28 +- 9.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2182 W: 683 L: 537 D: 962
Penta | [44, 218, 445, 316, 68]

LTC
Elo   | 34.54 +- 11.28 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1302 W: 386 L: 257 D: 659
Penta | [12, 109, 297, 204, 29]

Bench: 1621499