### PR TITLE
QS SEE Pruning

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -8,6 +8,7 @@
 #include "rose/nnue/nnue.hpp"
 #include "rose/score.hpp"
 #include "rose/search_control.hpp"
+#include "rose/see.hpp"
 #include "rose/tt.hpp"
 #include "rose/util/assert.hpp"
 #include "rose/util/defer.hpp"
@@ -497,6 +498,8 @@ namespace rose {
     if (ply >= max_depth)
       return eval(position);
 
+    const bool is_in_check = position.is_in_check();
+
     const Score static_eval = eval(position);
 
     // Standpat
@@ -513,6 +516,12 @@ namespace rose {
     tt::Bound bound = tt::Bound::upper_bound;
 
     for (Move mv = moves.next(); mv.is_some(); mv = moves.next()) {
+      if (!score::is_loss(best_score) && !is_in_check) {
+        // QS SEE Pruning
+        if (!see::see(position, mv, 0))
+          continue;
+      }
+
       const Position child_position = position.move(mv);
       make_move(ss, child_position, mv);
       rose_defer {


### PR DESCRIPTION
STC
Elo   | 76.87 +- 18.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 712 W: 283 L: 128 D: 301
Penta | [7, 48, 128, 129, 44]

LTC
Elo   | 59.96 +- 14.66 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 790 W: 272 L: 137 D: 381
Penta | [5, 49, 172, 144, 25]

Bench: 8126949