### PR TITLE
Singular Extensions: Double Extension

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -358,6 +358,7 @@ namespace rose {
       move_count++;
 
       i32 extension = 0;
+      // Singular Extensions
       if (!Node::is_root && depth >= 9 && mv == tte.move && !excluded && tte.depth >= depth - 3 && tte.bound != tt::Bound::upper_bound) {
         const Score singular_beta = std::max(score::min_score, tte.score - 2 * depth);
         const i32 singular_depth = depth / 2;
@@ -368,6 +369,7 @@ namespace rose {
 
         if (singular_score < singular_beta) {
           extension = 1;
+          extension += !Node::is_pv && singular_score <= singular_beta - 20;
         }
       }
 


### PR DESCRIPTION
STC
Elo   | 6.37 +- 4.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9492 W: 2635 L: 2461 D: 4396
Penta | [187, 1104, 2022, 1214, 219]

LTC
Elo   | 14.21 +- 7.14 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3352 W: 869 L: 732 D: 1751
Penta | [43, 357, 760, 452, 64]

Bench: 8941486