### PR TITLE
Noisy history

### DIFF
--- a/src/rose/history.hpp
+++ b/src/rose/history.hpp
@@ -37,6 +37,27 @@ namespace rose {
     }
   };
 
+  struct NoisyHistory {
+  private:
+    constexpr static i32 entry_max = 8192;
+
+    multi_array<i16, Color::count, Square::count, Square::count, PieceType::count> m_table {};
+
+  public:
+    auto reset() -> void {
+      m_table = {};
+    }
+
+    auto update(Color stm, Move mv, PieceType captured, i32 bonus) -> void {
+      i16& entry = m_table[stm.to_index()][mv.from().to_index()][mv.to().to_index()][captured.to_index()];
+      gravity_formula<entry_max>(entry, bonus);
+    }
+
+    auto get(Color stm, Move mv, PieceType captured) const -> i32 {
+      return m_table[stm.to_index()][mv.from().to_index()][mv.to().to_index()][captured.to_index()];
+    }
+  };
+
   struct ContinuationHistorySubtable {
   private:
     constexpr static i32 entry_max = 8192;

--- a/src/rose/history.hpp
+++ b/src/rose/history.hpp
@@ -41,7 +41,7 @@ namespace rose {
   private:
     constexpr static i32 entry_max = 8192;
 
-    multi_array<i16, Color::count, PieceType::count, Square::count> m_table {};
+    multi_array<i16, Color::count, PieceType::count, Square::count, Square::count> m_table {};
 
   public:
     auto reset() -> void {
@@ -49,12 +49,12 @@ namespace rose {
     }
 
     auto update(Color stm, PieceType attacker, Move mv, i32 bonus) -> void {
-      i16& entry = m_table[stm.to_index()][attacker.to_index()][mv.to().to_index()];
+      i16& entry = m_table[stm.to_index()][attacker.to_index()][mv.from().to_index()][mv.to().to_index()];
       gravity_formula<entry_max>(entry, bonus);
     }
 
     auto get(Color stm, PieceType attacker, Move mv) const -> i32 {
-      return m_table[stm.to_index()][attacker.to_index()][mv.to().to_index()];
+      return m_table[stm.to_index()][attacker.to_index()][mv.from().to_index()][mv.to().to_index()];
     }
   };
 

--- a/src/rose/history.hpp
+++ b/src/rose/history.hpp
@@ -41,20 +41,20 @@ namespace rose {
   private:
     constexpr static i32 entry_max = 8192;
 
-    multi_array<i16, Color::count, Square::count, Square::count, PieceType::count> m_table {};
+    multi_array<i16, Color::count, PieceType::count, Square::count> m_table {};
 
   public:
     auto reset() -> void {
       m_table = {};
     }
 
-    auto update(Color stm, Move mv, PieceType captured, i32 bonus) -> void {
-      i16& entry = m_table[stm.to_index()][mv.from().to_index()][mv.to().to_index()][captured.to_index()];
+    auto update(Color stm, PieceType attacker, Move mv, i32 bonus) -> void {
+      i16& entry = m_table[stm.to_index()][attacker.to_index()][mv.to().to_index()];
       gravity_formula<entry_max>(entry, bonus);
     }
 
-    auto get(Color stm, Move mv, PieceType captured) const -> i32 {
-      return m_table[stm.to_index()][mv.from().to_index()][mv.to().to_index()][captured.to_index()];
+    auto get(Color stm, PieceType attacker, Move mv) const -> i32 {
+      return m_table[stm.to_index()][attacker.to_index()][mv.to().to_index()];
     }
   };
 

--- a/src/rose/move_picker.cpp
+++ b/src/rose/move_picker.cpp
@@ -109,7 +109,7 @@ namespace rose {
       const PieceType victim = m_position.ptype_at(mv.to());
       const PieceType attacker = m_position.ptype_at(mv.from());
 
-      i32 score;
+      i32 score = 0;
       score += victim_score[victim.to_index()] * 8;
       score += m_search.m_noisy_history.get(stm, attacker, mv);
 

--- a/src/rose/move_picker.cpp
+++ b/src/rose/move_picker.cpp
@@ -97,15 +97,24 @@ namespace rose {
     m_moves.clear();
     m_movegen.generate_noisy(m_moves);
 
+    StaticVector<i32, max_legal_moves> scores;
+    scores.resize(m_moves.size());
+
     const Color stm = m_position.stm();
 
-    StaticVector<i32, max_legal_moves> scores;
+    constexpr std::array<i32, 8> victim_score {{0, 100000, 1000, 3000, 0, 3000, 5000, 9000}};
 
-    scores.resize(m_moves.size());
     for (isize i = 0; i < m_moves.size(); i++) {
       const Move mv = m_moves[i];
-      scores[i] = m_position.board()[mv.to()].ptype().to_sort_value() * 0x10000 - m_position.board()[mv.from()].ptype().to_sort_value() * 0x100 - i;
+      const PieceType victim = m_position.ptype_at(mv.to());
+
+      i32 score;
+      score += victim_score[victim.to_index()];
+      score += m_search.m_noisy_history.get(stm, mv, victim);
+
+      scores[i] = score * 256 - i;
     }
+
     std::ranges::sort(std::ranges::zip_view(m_moves, scores), [](auto&& a, auto&& b) {
       return std::get<1>(a) > std::get<1>(b);
     });

--- a/src/rose/move_picker.cpp
+++ b/src/rose/move_picker.cpp
@@ -102,14 +102,14 @@ namespace rose {
 
     const Color stm = m_position.stm();
 
-    constexpr std::array<i32, 8> victim_score {{0, 100000, 1000, 3000, 0, 3000, 5000, 9000}};
+    constexpr std::array<i32, 8> victim_score {{0, 10000, 100, 300, 0, 300, 500, 900}};
 
     for (isize i = 0; i < m_moves.size(); i++) {
       const Move mv = m_moves[i];
       const PieceType victim = m_position.ptype_at(mv.to());
 
       i32 score;
-      score += victim_score[victim.to_index()];
+      score += victim_score[victim.to_index()] * 8;
       score += m_search.m_noisy_history.get(stm, mv, victim);
 
       scores[i] = score * 256 - i;

--- a/src/rose/move_picker.cpp
+++ b/src/rose/move_picker.cpp
@@ -102,7 +102,7 @@ namespace rose {
 
     const Color stm = m_position.stm();
 
-    constexpr std::array<i32, 8> victim_score {{0, 10000, 100, 300, 0, 300, 500, 900}};
+    constexpr std::array<i32, 8> victim_score {{0, 10000, 100, 300, 0, 350, 500, 900}};
 
     for (isize i = 0; i < m_moves.size(); i++) {
       const Move mv = m_moves[i];

--- a/src/rose/move_picker.cpp
+++ b/src/rose/move_picker.cpp
@@ -107,10 +107,11 @@ namespace rose {
     for (isize i = 0; i < m_moves.size(); i++) {
       const Move mv = m_moves[i];
       const PieceType victim = m_position.ptype_at(mv.to());
+      const PieceType attacker = m_position.ptype_at(mv.from());
 
       i32 score;
       score += victim_score[victim.to_index()] * 8;
-      score += m_search.m_noisy_history.get(stm, mv, victim);
+      score += m_search.m_noisy_history.get(stm, attacker, mv);
 
       scores[i] = score * 256 - i;
     }

--- a/src/rose/position.hpp
+++ b/src/rose/position.hpp
@@ -205,6 +205,10 @@ namespace rose {
       return m_board.mailbox[sq.raw];
     }
 
+    auto ptype_at(Square sq) const -> PieceType {
+      return place_at(sq).ptype();
+    }
+
     template<PieceType... ptypes>
     auto piece_mask_for(Color color) const -> PieceMask {
       return piece_list_type(color).piece_mask_for<ptypes...>();

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -65,6 +65,7 @@ namespace rose {
 
   auto Search::reset() -> void {
     m_quiet_history.reset();
+    m_noisy_history.reset();
     m_continuation_history.reset();
   }
 
@@ -438,13 +439,21 @@ namespace rose {
     if (best_move.is_some()) {
       const Color stm = position.stm();
 
+      const i32 noisy_bonus = 150 * depth - 75;
+      const i32 noisy_malus = 75 * depth - 30;
+
       const i32 quiet_bonus = 150 * depth - 75;
       const i32 quiet_malus = 75 * depth - 30;
 
       const i32 cont_bonus = 150 * depth - 75;
       const i32 cont_malus = 75 * depth - 30;
 
-      if (!best_move.capture()) {
+      if (best_move.capture()) {
+        m_noisy_history.update(stm, best_move, position.ptype_at(best_move.to()), noisy_bonus);
+        for (const Move noisy : fail_low_noisies) {
+          m_noisy_history.update(stm, noisy, position.ptype_at(noisy.to()), -noisy_malus);
+        }
+      } else {
         m_quiet_history.update(stm, best_move, quiet_bonus);
         for (i32 i : {1, 2})
           if (ss[-i].conthist)

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -449,9 +449,9 @@ namespace rose {
       const i32 cont_malus = 75 * depth - 30;
 
       if (best_move.capture()) {
-        m_noisy_history.update(stm, best_move, position.ptype_at(best_move.to()), noisy_bonus);
+        m_noisy_history.update(stm, position.ptype_at(best_move.from()), best_move, noisy_bonus);
         for (const Move noisy : fail_low_noisies) {
-          m_noisy_history.update(stm, noisy, position.ptype_at(noisy.to()), -noisy_malus);
+          m_noisy_history.update(stm, position.ptype_at(noisy.from()), noisy, -noisy_malus);
         }
       } else {
         m_quiet_history.update(stm, best_move, quiet_bonus);

--- a/src/rose/search.hpp
+++ b/src/rose/search.hpp
@@ -116,6 +116,7 @@ namespace rose {
     std::array<SearchStack, max_depth + search_stack_offset + search_stack_safety> m_search_stack;
 
     QuietHistory m_quiet_history;
+    NoisyHistory m_noisy_history;
     ContinuationHistory m_continuation_history;
 
   public:


### PR DESCRIPTION
STC
Elo   | 9.13 +- 5.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.09 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6664 W: 1911 L: 1736 D: 3017
Penta | [150, 761, 1369, 868, 184]

LTC
Elo   | 12.61 +- 6.67 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3996 W: 1061 L: 916 D: 2019
Penta | [51, 460, 861, 545, 81]

Bench: 8811992