### PR TITLE
QS TT Cutoff

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -511,6 +511,24 @@ namespace rose {
 
     const bool is_in_check = position.is_in_check();
 
+    const tt::LookupResult tte = tt_load(position, ply);
+
+    // Transposition Table Cutoffs
+    if (leaf_expected != NodeType::pv && tte.is_some() && [&] {
+          switch (tte.bound.raw) {
+          case NodeType::none:
+            return false;
+          case NodeType::cut:
+            return tte.score >= beta;
+          case NodeType::pv:
+            return true;
+          case NodeType::all:
+            return tte.score <= alpha;
+          }
+        }()) {
+      return tte.score;
+    }
+
     const Score static_eval = is_in_check ? score::mated(ply) : eval(position);
 
     // Standpat


### PR DESCRIPTION
STC
Elo   | 10.33 +- 6.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5486 W: 1606 L: 1443 D: 2437
Penta | [122, 614, 1147, 699, 161]

LTC
Elo   | 8.08 +- 5.02 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6578 W: 1708 L: 1555 D: 3315
Penta | [88, 721, 1543, 824, 113]

Bench: 7759704