### PR TITLE
LMR: Reduce captures less

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -383,6 +383,10 @@ namespace rose {
 
         i32 reduction = 2048 + 256 * log2_depth * log2_move_count;
 
+        if (mv.capture()) {
+          reduction -= 512;
+        }
+
         const i32 lmr_depth = std::clamp(new_depth - reduction / 1024, 0, new_depth);
 
         score = -search<expected.next()>(ctrl, child_position, child_pv, -alpha - 1, -alpha, ss + 1, ply + 1, lmr_depth);


### PR DESCRIPTION
STC
Elo   | 2.46 +- 1.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 57024 W: 15714 L: 15311 D: 25999
Penta | [1309, 6813, 11952, 7042, 1396]

LTC
Elo   | 2.78 +- 2.25 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 33166 W: 8289 L: 8024 D: 16853
Penta | [476, 3921, 7588, 4058, 540]

Bench: 8662613