### PR TITLE
Razoring

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -311,6 +311,14 @@ namespace rose {
           return beta;
         }
       }
+
+      // Razoring
+      if (depth <= 4 && static_eval + 600 * depth < alpha) {
+        const Score razor_score = qsearch<expected.narrow()>(ctrl, position, pv, alpha, beta, ss, ply);
+        if (razor_score <= alpha) {
+          return razor_score;
+        }
+      }
     }
 
     MovePicker moves {*this, position, ss, tte.move};


### PR DESCRIPTION
STC
Elo   | 4.87 +- 3.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 14496 W: 3988 L: 3785 D: 6723
Penta | [321, 1701, 3046, 1814, 366]

LTC
Elo   | 3.80 +- 3.03 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 18470 W: 4646 L: 4444 D: 9380
Penta | [257, 2216, 4116, 2360, 286]

Bench: 8034612