### PR TITLE
Null move reductions

### DIFF
--- a/src/rose/position.cpp
+++ b/src/rose/position.cpp
@@ -226,17 +226,17 @@ namespace rose {
     new_pos.m_cached_pinned = {};
     new_pos.m_cached_masked_attack_table = {};
 
+    if (new_pos.m_enpassant.is_valid()) {
+      new_pos.m_hash ^= hash::enpassant_table[new_pos.m_enpassant.file()];
+      new_pos.m_enpassant = Square::invalid();
+    }
+
     const Square from = m.from();
     const Square to = m.to();
     const Place src_place = m_board[from];
     const Place dest_place = m_board[to];
     const PieceId src_id = src_place.id();
     const PieceId dest_id = dest_place.id();
-
-    if (new_pos.m_enpassant.is_valid()) {
-      new_pos.m_hash ^= hash::enpassant_table[new_pos.m_enpassant.file()];
-      new_pos.m_enpassant = Square::invalid();
-    }
 
     const auto check_src_castling_rights = [&] {
       new_pos.m_rook_info.unset(m_stm, from);
@@ -386,6 +386,35 @@ namespace rose {
                 to_string(MoveFormat::frc),
                 m_hash,
                 m.to_string(MoveFormat::frc),
+                new_pos.to_string(MoveFormat::frc),
+                new_pos.m_hash,
+                new_pos.calc_hash_slow());
+
+    return new_pos;
+  }
+
+  auto Position::null_move() const -> Position {
+    Position new_pos = *this;
+    new_pos.m_valid_pin_info = false;
+    new_pos.m_cached_pinned = {};
+    new_pos.m_cached_masked_attack_table = {};
+
+    if (new_pos.m_enpassant.is_valid()) {
+      new_pos.m_hash ^= hash::enpassant_table[new_pos.m_enpassant.file()];
+      new_pos.m_enpassant = Square::invalid();
+    }
+
+    new_pos.m_50mr++;
+
+    new_pos.m_hash ^= hash::move;
+
+    new_pos.m_ply++;
+    new_pos.m_stm = !m_stm;
+
+    rose_assert(new_pos.m_hash == new_pos.calc_hash_slow(),
+                "{} [{:016x}] : {} : (null move) [{:016x} {:016x}]",
+                to_string(MoveFormat::frc),
+                m_hash,
                 new_pos.to_string(MoveFormat::frc),
                 new_pos.m_hash,
                 new_pos.calc_hash_slow());

--- a/src/rose/position.hpp
+++ b/src/rose/position.hpp
@@ -234,6 +234,7 @@ namespace rose {
     auto is_repetition(const std::vector<u64>& hash_stack, usize hash_waterline) const -> bool;
 
     auto move(Move m) const -> Position;
+    auto null_move() const -> Position;
 
     auto calc_hash_slow() const -> Hash;
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -321,14 +321,15 @@ namespace rose {
         if (m_shared.stopping)
           return 0;
 
-        if (m_nmr_ply.has_value()) {
-          if (null_score >= beta)
+        if (null_score >= beta) {
+          if (m_nmr_ply.has_value()) {
             return null_score;
-        } else {
-          m_nmr_ply = ply;
-          const Score score = search<expected>(ctrl, position, pv, alpha, beta, ss, ply, depth - 2);
-          m_nmr_ply = std::nullopt;
-          return score;
+          } else {
+            m_nmr_ply = ply;
+            const Score score = search<expected>(ctrl, position, pv, alpha, beta, ss, ply, depth - 2);
+            m_nmr_ply = std::nullopt;
+            return score;
+          }
         }
       }
     }

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -603,6 +603,12 @@ namespace rose {
     ss->conthist = m_continuation_history.get_subtable(!child_position.stm(), child_position.place_at(mv.to()).ptype(), mv);
   }
 
+  auto Search::make_null_move(SearchStack* ss, const Position& child_position) -> void {
+    m_hash_stack.push_back(child_position.hash());
+    ss->move = Move::none();
+    ss->conthist = nullptr;
+  }
+
   auto Search::unmake_move(SearchStack* ss) -> void {
     m_hash_stack.pop_back();
     ss->move = Move::none();

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -308,6 +308,29 @@ namespace rose {
           return razor_score;
         }
       }
+
+      // Null move reductions
+      if (depth >= 4 && m_nmr_ply != ply && ss[-1].move.is_some() && static_eval >= beta) {
+        const i32 reduction = 4;
+
+        const Position null_position = position.null_move();
+        make_null_move(ss, null_position);
+        const Score null_score = -search<NodeType::all>(ctrl, null_position, pv, -beta, -beta + 1, ss + 1, ply + 1, depth - reduction);
+        unmake_move(ss);
+
+        if (m_shared.stopping)
+          return 0;
+
+        if (m_nmr_ply.has_value()) {
+          if (null_score >= beta)
+            return null_score;
+        } else {
+          m_nmr_ply = ply;
+          const Score score = search<expected>(ctrl, position, pv, alpha, beta, ss, ply, depth - 2);
+          m_nmr_ply = std::nullopt;
+          return score;
+        }
+      }
     }
 
     MovePicker moves {*this, position, ss, tte.move};

--- a/src/rose/search.hpp
+++ b/src/rose/search.hpp
@@ -153,6 +153,7 @@ namespace rose {
     auto tt_store(const Position& position, i32 ply, tt::LookupResult lr) -> void;
 
     auto make_move(SearchStack* ss, const Position& child_position, Move mv) -> void;
+    auto make_null_move(SearchStack* ss, const Position& child_position) -> void;
     auto unmake_move(SearchStack* ss) -> void;
   };
 

--- a/src/rose/search.hpp
+++ b/src/rose/search.hpp
@@ -119,6 +119,8 @@ namespace rose {
     NoisyHistory m_noisy_history;
     ContinuationHistory m_continuation_history;
 
+    std::optional<i32> m_nmr_ply;
+
   public:
     Search(int id, SearchShared& shared) :
         m_id(id),


### PR DESCRIPTION
STC
Elo   | 10.47 +- 6.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5280 W: 1563 L: 1404 D: 2313
Penta | [124, 566, 1122, 683, 145]

LTC
Elo   | 18.08 +- 7.96 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2520 W: 713 L: 582 D: 1225
Penta | [32, 236, 600, 353, 39]

Bench: 8089160