### PR TITLE
4-Ply continuation history

### DIFF
--- a/src/rose/move_picker.cpp
+++ b/src/rose/move_picker.cpp
@@ -136,7 +136,7 @@ namespace rose {
 
       i32 score = 0;
       score += m_search.m_quiet_history.get(stm, mv);
-      for (i32 i : {1, 2})
+      for (i32 i : {1, 2, 4})
         if (m_ss[-i].conthist)
           score += m_ss[-i].conthist->get(stm, ptype, mv);
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -480,12 +480,12 @@ namespace rose {
         }
       } else {
         m_quiet_history.update(stm, best_move, quiet_bonus);
-        for (i32 i : {1, 2})
+        for (i32 i : {1, 2, 4})
           if (ss[-i].conthist)
             ss[-i].conthist->update(stm, position.place_at(best_move.from()).ptype(), best_move, cont_bonus);
         for (const Move quiet : fail_low_quiets) {
           m_quiet_history.update(stm, quiet, -quiet_malus);
-          for (i32 i : {1, 2})
+          for (i32 i : {1, 2, 4})
             if (ss[-i].conthist)
               ss[-i].conthist->update(stm, position.place_at(quiet.from()).ptype(), quiet, -cont_malus);
         }


### PR DESCRIPTION
STC
Elo   | 9.44 +- 5.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5890 W: 1710 L: 1550 D: 2630
Penta | [125, 652, 1257, 760, 151]

LTC
Elo   | 4.20 +- 3.28 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 15538 W: 3949 L: 3761 D: 7828
Penta | [219, 1825, 3505, 1989, 231]

Bench: 7796800