### PR TITLE
NMR: Adjust zws-reduction by depth

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -320,7 +320,7 @@ namespace rose {
 
       // Null move reductions
       if (depth >= 4 && m_nmr_ply != ply && ss[-1].move.is_some() && static_eval >= beta) {
-        const i32 reduction = 4;
+        const i32 reduction = 4 + depth / 3;
 
         const Position null_position = make_null_move(ss, position);
         const Score null_score = -search<NodeType::all>(ctrl, null_position, pv, -beta, -beta + 1, ss + 1, ply + 1, depth - reduction);


### PR DESCRIPTION
STC
Elo   | 10.46 +- 6.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4952 W: 1384 L: 1235 D: 2333
Penta | [77, 548, 1111, 629, 111]

LTC
Elo   | 29.71 +- 10.48 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1512 W: 445 L: 316 D: 751
Penta | [15, 131, 355, 220, 35]

Bench: 5701954