### PR TITLE
LMR: Log-formula dependent on move noisiness

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -410,7 +410,7 @@ namespace rose {
       Score score = score::none;
 
       // Late Move Reductions
-      if (depth >= 4 && move_count >= 3) {
+      if (depth >= 3 && move_count >= 2) {
         const i32 log2_depth = std::bit_width(static_cast<u32>(depth)) - 1;
         const i32 log2_move_count = std::bit_width(static_cast<u32>(move_count)) - 1;
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -375,8 +375,6 @@ namespace rose {
         }
       }
 
-      move_count++;
-
       i32 extension = 0;
       // Singular Extensions
       if (!is_root && depth >= 9 && mv == tte.move && !excluded && tte.depth >= depth - 3 && tte.bound.is_pv_or_cut()) {
@@ -400,6 +398,8 @@ namespace rose {
         }
       }
 
+      move_count++;
+
       const Position child_position = make_move(ss, position, mv);
       rose_defer {
         unmake_move(ss);
@@ -410,7 +410,7 @@ namespace rose {
       Score score = score::none;
 
       // Late Move Reductions
-      if (depth >= 2 && move_count >= 3) {
+      if (depth >= 3 && move_count >= 2 + 2 * (expected == NodeType::pv)) {
         const i32 log2_depth = std::bit_width(static_cast<u32>(depth)) - 1;
         const i32 log2_move_count = std::bit_width(static_cast<u32>(move_count)) - 1;
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -417,7 +417,7 @@ namespace rose {
         i32 reduction;
 
         if (mv.noisy()) {
-          reduction = 768 + 128 * log2_depth * log2_move_count;
+          reduction = 1024 + 192 * log2_depth * log2_move_count;
         } else {
           reduction = 2048 + 256 * log2_depth * log2_move_count;
         }

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -410,7 +410,7 @@ namespace rose {
       Score score = score::none;
 
       // Late Move Reductions
-      if (depth >= 3 && move_count >= 3) {
+      if (depth >= 2 && move_count >= 3) {
         const i32 log2_depth = std::bit_width(static_cast<u32>(depth)) - 1;
         const i32 log2_move_count = std::bit_width(static_cast<u32>(move_count)) - 1;
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -410,7 +410,7 @@ namespace rose {
       Score score = score::none;
 
       // Late Move Reductions
-      if (depth >= 3 && move_count >= 2 + 2 * (expected == NodeType::pv)) {
+      if (depth >= 4 && move_count >= 3) {
         const i32 log2_depth = std::bit_width(static_cast<u32>(depth)) - 1;
         const i32 log2_move_count = std::bit_width(static_cast<u32>(move_count)) - 1;
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -410,14 +410,16 @@ namespace rose {
       Score score = score::none;
 
       // Late Move Reductions
-      if (depth >= 3 && move_count >= 4) {
+      if (depth >= 3 && move_count > 2) {
         const i32 log2_depth = std::bit_width(static_cast<u32>(depth)) - 1;
         const i32 log2_move_count = std::bit_width(static_cast<u32>(move_count)) - 1;
 
-        i32 reduction = 2048 + 256 * log2_depth * log2_move_count;
+        i32 reduction;
 
-        if (mv.capture()) {
-          reduction -= 512;
+        if (mv.noisy()) {
+          reduction = 768 + 128 * log2_depth * log2_move_count;
+        } else {
+          reduction = 2048 + 256 * log2_depth * log2_move_count;
         }
 
         const i32 lmr_depth = std::clamp(new_depth - reduction / 1024, 0, new_depth);

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -410,7 +410,7 @@ namespace rose {
       Score score = score::none;
 
       // Late Move Reductions
-      if (depth >= 3 && move_count >= 2) {
+      if (depth >= 3 && move_count >= 4) {
         const i32 log2_depth = std::bit_width(static_cast<u32>(depth)) - 1;
         const i32 log2_move_count = std::bit_width(static_cast<u32>(move_count)) - 1;
 


### PR DESCRIPTION
STC
Elo   | 9.71 +- 5.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5476 W: 1487 L: 1334 D: 2655
Penta | [96, 614, 1186, 725, 117]

LTC
Elo   | 7.28 +- 4.75 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7160 W: 1809 L: 1659 D: 3692
Penta | [75, 835, 1646, 913, 111]

Bench: 5838751