### PR TITLE
No move loop pruning in root

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -356,7 +356,7 @@ namespace rose {
       if (mv == ss->excluded)
         continue;
 
-      if (!score::is_loss(best_score) && !is_in_check) {
+      if (!score::is_loss(best_score) && !is_in_check && !is_root) {
         // Late Move Pruning
         if (!mv.noisy() && searched_moves >= (4 + depth * depth) / (2 - improving)) {
           moves.skip_quiet();


### PR DESCRIPTION
STC
Elo   | 4.06 +- 4.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 7876 W: 2074 L: 1982 D: 3820
Penta | [142, 940, 1709, 978, 169]

LTC (incomplete)
Elo   | -1.25 +- 2.04 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.57 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 38030 W: 9029 L: 9166 D: 19835
Penta | [493, 4630, 8891, 4523, 478]

Bench: 5489844