### PR TITLE
NMR: Increase reduction

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -334,9 +334,10 @@ namespace rose {
             return null_score;
           } else {
             m_nmr_ply = ply;
-            const Score score = search<expected>(ctrl, position, pv, alpha, beta, ss, ply, depth - 2);
+            const Score score = search<expected>(ctrl, position, pv, alpha, beta, ss, ply, depth / 2);
             m_nmr_ply = std::nullopt;
-            return score;
+            if (score >= beta)
+              return score;
           }
         }
       }


### PR DESCRIPTION
STC
Elo   | 14.63 +- 7.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3492 W: 1002 L: 855 D: 1635
Penta | [60, 377, 754, 466, 89]

LTC
Elo   | 17.08 +- 7.78 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2688 W: 715 L: 583 D: 1390
Penta | [31, 270, 624, 374, 45]

Bench: 4935759