### PR TITLE
Post-LMR continuation history update

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -277,6 +277,7 @@ namespace rose {
 
     const bool excluded = ss->excluded.is_some();
     const bool is_in_check = position.is_in_check();
+    const Color stm = position.stm();
 
     const tt::LookupResult tte = tt_load(position, ply);
 
@@ -358,7 +359,6 @@ namespace rose {
         continue;
 
       const i32 history = [&] {
-        const Color stm = position.stm();
         const PieceType ptype = position.ptype_at(mv.from());
 
         i32 history = 0;
@@ -449,6 +449,16 @@ namespace rose {
 
         if (score > alpha && lmr_depth < new_depth) {
           score = -search<expected.next()>(ctrl, child_position, child_pv, -alpha - 1, -alpha, ss + 1, ply + 1, new_depth);
+
+          // Post-LMR continuation history update
+          if (!mv.noisy() && (score <= alpha || score >= beta)) {
+            const i32 cont_bonus = 150 * depth - 75;
+            const i32 cont_malus = 75 * depth - 30;
+
+            for (i32 i : {1, 2, 4})
+              if (ss[-i].conthist)
+                ss[-i].conthist->update(stm, position.place_at(mv.from()).ptype(), mv, score <= alpha ? -cont_malus : cont_bonus);
+          }
         }
       }
       // PVS Scout Search
@@ -497,8 +507,6 @@ namespace rose {
     }
 
     if (best_move.is_some()) {
-      const Color stm = position.stm();
-
       const i32 noisy_bonus = 150 * depth - 75;
       const i32 noisy_malus = 75 * depth - 30;
 


### PR DESCRIPTION
STC
Elo   | 11.13 +- 6.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.05 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4996 W: 1366 L: 1206 D: 2424
Penta | [84, 576, 1072, 628, 138]

LTC
Elo   | 8.64 +- 5.26 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5712 W: 1456 L: 1314 D: 2942
Penta | [62, 644, 1312, 766, 72]

Bench: 6397578