### PR TITLE
Cap all history bonuses

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -452,8 +452,8 @@ namespace rose {
 
           // Post-LMR continuation history update
           if (!mv.noisy() && (score <= alpha || score >= beta)) {
-            const i32 cont_bonus = 150 * depth - 75;
-            const i32 cont_malus = 75 * depth - 30;
+            const i32 cont_bonus = std::min(150 * depth - 75, 1536);
+            const i32 cont_malus = std::min(75 * depth - 30, 1024);
 
             for (i32 i : {1, 2, 4})
               if (ss[-i].conthist)
@@ -507,14 +507,14 @@ namespace rose {
     }
 
     if (best_move.is_some()) {
-      const i32 noisy_bonus = 150 * depth - 75;
-      const i32 noisy_malus = 75 * depth - 30;
+      const i32 noisy_bonus = std::min(150 * depth - 75, 1536);
+      const i32 noisy_malus = std::min(75 * depth - 30, 1024);
 
-      const i32 quiet_bonus = 150 * depth - 75;
-      const i32 quiet_malus = 75 * depth - 30;
+      const i32 quiet_bonus = std::min(150 * depth - 75, 1536);
+      const i32 quiet_malus = std::min(75 * depth - 30, 1024);
 
-      const i32 cont_bonus = 150 * depth - 75;
-      const i32 cont_malus = 75 * depth - 30;
+      const i32 cont_bonus = std::min(150 * depth - 75, 1536);
+      const i32 cont_malus = std::min(75 * depth - 30, 1024);
 
       if (best_move.noisy()) {
         m_sd.noisy_history.update(stm, position.ptype_at(best_move.from()), best_move, noisy_bonus);

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -277,6 +277,7 @@ namespace rose {
 
     const bool excluded = ss->excluded.is_some();
     const bool is_in_check = position.is_in_check();
+    const Color stm = position.stm();
 
     const tt::LookupResult tte = tt_load(position, ply);
 
@@ -358,7 +359,6 @@ namespace rose {
         continue;
 
       const i32 history = [&] {
-        const Color stm = position.stm();
         const PieceType ptype = position.ptype_at(mv.from());
 
         i32 history = 0;
@@ -449,6 +449,16 @@ namespace rose {
 
         if (score > alpha && lmr_depth < new_depth) {
           score = -search<expected.next()>(ctrl, child_position, child_pv, -alpha - 1, -alpha, ss + 1, ply + 1, new_depth);
+
+          // Post-LMR continuation history update
+          if (!mv.noisy() && (score <= alpha || score >= beta)) {
+            const i32 cont_bonus = 150 * depth - 75;
+            const i32 cont_malus = 75 * depth - 30;
+
+            for (i32 i : {1, 2, 4})
+              if (ss[-i].conthist)
+                ss[-i].conthist->update(stm, position.place_at(mv.from()).ptype(), mv, score <= alpha ? -cont_malus : cont_bonus);
+          }
         }
       }
       // PVS Scout Search
@@ -497,8 +507,6 @@ namespace rose {
     }
 
     if (best_move.is_some()) {
-      const Color stm = position.stm();
-
       const i32 noisy_bonus = 150 * depth - 75;
       const i32 noisy_malus = 75 * depth - 30;
 


### PR DESCRIPTION
STC
Elo   | 3.91 +- 3.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 19286 W: 5063 L: 4846 D: 9377
Penta | [327, 2330, 4201, 2369, 416]

LTC
Elo   | 6.32 +- 4.33 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8360 W: 2094 L: 1942 D: 4324
Penta | [89, 950, 1980, 1042, 119]

Bench: 5141792