### PR TITLE
LMR: Less reduction in expected PV nodes

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -442,6 +442,7 @@ namespace rose {
         } else {
           reduction = 2048 + 256 * log2_depth * log2_searched_moves;
         }
+        reduction -= 1024 * (expected == NodeType::pv);
 
         const i32 lmr_depth = std::clamp(new_depth - reduction / 1024, 0, new_depth);
 


### PR DESCRIPTION
STC
Elo   | 7.65 +- 5.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7448 W: 2068 L: 1904 D: 3476
Penta | [135, 872, 1602, 924, 191]

LTC
Elo   | 5.62 +- 3.97 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9956 W: 2439 L: 2278 D: 5239
Penta | [99, 1180, 2290, 1279, 130]

Bench: 7187940