### PR TITLE
LMR: Do deeper

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -453,7 +453,12 @@ namespace rose {
         score = -search<expected.next()>(ctrl, child_position, child_pv, -alpha - 1, -alpha, ss + 1, ply + 1, lmr_depth);
 
         if (score > alpha && lmr_depth < new_depth) {
-          score = -search<expected.next()>(ctrl, child_position, child_pv, -alpha - 1, -alpha, ss + 1, ply + 1, new_depth);
+          i32 research_depth = new_depth;
+          if (!is_root) {
+            research_depth += score > best_score + 64;
+          }
+
+          score = -search<expected.next()>(ctrl, child_position, child_pv, -alpha - 1, -alpha, ss + 1, ply + 1, research_depth);
 
           // Post-LMR continuation history update
           if (!mv.noisy() && (score <= alpha || score >= beta)) {


### PR DESCRIPTION
STC
Elo   | 4.90 +- 3.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 12046 W: 3054 L: 2884 D: 6108
Penta | [146, 1381, 2819, 1511, 166]

LTC
Elo   | 3.75 +- 2.94 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 16028 W: 3848 L: 3675 D: 8505
Penta | [108, 1863, 3915, 2004, 124]

Bench: 7261581