### PR TITLE
LMR: History reductions

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -444,9 +444,10 @@ namespace rose {
         if (mv.noisy()) {
           reduction = 1024 + 192 * log2_depth * log2_searched_moves;
         } else {
-          reduction = 2048 + 256 * log2_depth * log2_searched_moves;
+          reduction = 2176 + 256 * log2_depth * log2_searched_moves;
         }
         reduction -= 1024 * (expected == NodeType::pv);
+        reduction -= 128 * history / 1024;
 
         const i32 lmr_depth = std::clamp(new_depth - reduction / 1024, 0, new_depth);
 


### PR DESCRIPTION
STC
Elo   | 21.85 +- 8.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2102 W: 600 L: 468 D: 1034
Penta | [24, 199, 496, 285, 47]

LTC
Elo   | 21.70 +- 8.49 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1892 W: 496 L: 378 D: 1018
Penta | [8, 183, 454, 285, 16]

Bench: 7335815