### PR TITLE
Quiet SEE pruning history tweak

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -391,8 +391,13 @@ namespace rose {
           continue;
         }
 
-        // SEE Pruning
-        if (depth <= 11 && !see::see(position, mv, mv.noisy() ? -64 * depth : -48 * depth)) {
+        // Quiet SEE Pruning
+        if (!mv.noisy() && depth <= 11 && !see::see(position, mv, -48 * depth - 32 * history / 1024)) {
+          continue;
+        }
+
+        // Noisy SEE Pruning
+        if (!mv.noisy() && depth <= 11 && !see::see(position, mv, -64 * depth)) {
           continue;
         }
       }

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -392,7 +392,7 @@ namespace rose {
         }
 
         // Quiet SEE Pruning
-        if (!mv.noisy() && depth <= 11 && !see::see(position, mv, -48 * depth - 64 * history / 1024)) {
+        if (!mv.noisy() && depth <= 11 && !see::see(position, mv, 32 - 48 * depth - 32 * history / 1024)) {
           continue;
         }
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -392,12 +392,12 @@ namespace rose {
         }
 
         // Quiet SEE Pruning
-        if (!mv.noisy() && depth <= 11 && !see::see(position, mv, -48 * depth - 32 * history / 1024)) {
+        if (!mv.noisy() && depth <= 11 && !see::see(position, mv, -48 * depth - 64 * history / 1024)) {
           continue;
         }
 
         // Noisy SEE Pruning
-        if (!mv.noisy() && depth <= 11 && !see::see(position, mv, -64 * depth)) {
+        if (mv.noisy() && depth <= 11 && !see::see(position, mv, -64 * depth)) {
           continue;
         }
       }


### PR DESCRIPTION
STC
Elo   | 5.61 +- 4.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10526 W: 2837 L: 2667 D: 5022
Penta | [154, 1231, 2334, 1379, 165]

LTC
Elo   | 6.07 +- 4.12 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8186 W: 2002 L: 1859 D: 4325
Penta | [52, 932, 1997, 1045, 67]

 Bench: 6684227 