### PR TITLE
Update network arch to Jasper<256> (007-eighth)

### DIFF
--- a/src/rose/eval/nnue/embedded.hpp
+++ b/src/rose/eval/nnue/embedded.hpp
@@ -4,7 +4,7 @@
 
 namespace rose::eval::nnue {
 
-  using EmbeddedArch = Jasper<128>;
+  using EmbeddedArch = Jasper<256>;
   using EmbeddedNetwork = EmbeddedArch::Network;
 
   alignas(EmbeddedNetwork) extern const char g_embedded_network_raw[];

--- a/src/rose/position.cpp
+++ b/src/rose/position.cpp
@@ -410,6 +410,7 @@ namespace rose {
 
   template auto Position::move<eval::NullObserver>(Move m, eval::NullObserver observer) const -> Position;
   template auto Position::move<eval::nnue::Jasper<128>::Observer>(Move m, eval::nnue::Jasper<128>::Observer observer) const -> Position;
+  template auto Position::move<eval::nnue::Jasper<256>::Observer>(Move m, eval::nnue::Jasper<256>::Observer observer) const -> Position;
 
   auto Position::null_move() const -> Position {
     Position new_pos = *this;

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -716,5 +716,6 @@ namespace rose {
   }
 
   template struct Search<eval::nnue::Jasper<128>::State>;
+  template struct Search<eval::nnue::Jasper<256>::State>;
 
 }  // namespace rose

--- a/src/rose_network.txt
+++ b/src/rose_network.txt
@@ -1,1 +1,1 @@
-006-seventh
+jasper256-ds20260301and03-wdl0.2-sb60

--- a/src/rose_network.txt
+++ b/src/rose_network.txt
@@ -1,1 +1,1 @@
-jasper256-ds20260301and03-wdl0.2-sb60
+007-eighth


### PR DESCRIPTION
Increase HL: 128 -> 256. WDL 0.2. SB 60.
Uses data generated by 005-sixth and 006-seventh.

FN
Elo   | 68.19 +- 9.41 (95%)
SPRT  | N=10000 Threads=1 Hash=16MB
LLR   | 11.29 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3416 W: 1537 L: 875 D: 1004
Penta | [83, 257, 593, 465, 310]

STC
Elo   | 44.63 +- 12.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.46 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1276 W: 432 L: 269 D: 575
Penta | [12, 109, 267, 204, 46]

LTC
Elo   | 44.60 +- 12.82 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1026 W: 338 L: 207 D: 481
Penta | [8, 82, 217, 183, 23]

Bench: 6845039