### PR TITLE
Add DFRC data to net (009-tenth)

### DIFF
--- a/src/rose_network.txt
+++ b/src/rose_network.txt
@@ -1,1 +1,1 @@
-008-ninth
+jasper256-ds20260606-wdl0.2-sb70

--- a/src/rose_network.txt
+++ b/src/rose_network.txt
@@ -1,1 +1,1 @@
-jasper256-ds20260606-wdl0.2-sb70
+jasper256-ds20260606-gentlelr-sb100

--- a/src/rose_network.txt
+++ b/src/rose_network.txt
@@ -1,1 +1,1 @@
-jasper256-ds20260606-and-04-standard-sb100
+009-tenth

--- a/src/rose_network.txt
+++ b/src/rose_network.txt
@@ -1,1 +1,1 @@
-jasper256-ds20260606-gentlelr-sb100
+jasper256-ds20260606-and-04-standard-sb100


### PR DESCRIPTION
80% DFRC data, 20% standard
Standard data is the same data used in the previous net. DFRC data was generated by previous net.

FN (standard)
Elo   | -3.58 +- 5.22 (95%)
SPRT  | N=10000 Threads=1 Hash=16MB
LLR   | -3.03 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10290 W: 3408 L: 3514 D: 3368
Penta | [514, 1137, 1917, 1095, 482]

FN (frc)
Elo   | 89.43 +- 22.11 (95%)
SPRT  | N=10000 Threads=1 Hash=16MB
LLR   | 3.11 (-2.25, 2.89) [0.00, 5.00]
Games | N: 806 W: 418 L: 215 D: 173
Penta | [27, 48, 132, 87, 109]

STC (standard)
Elo   | 6.47 +- 4.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8806 W: 2439 L: 2275 D: 4092
Penta | [128, 1048, 1944, 1098, 185]

STC (frc)
Elo   | 126.64 +- 22.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.56 (-2.25, 2.89) [0.00, 5.00]
Games | N: 610 W: 307 L: 94 D: 209
Penta | [1, 37, 86, 110, 71]

LTC (standard)
Elo   | 6.85 +- 4.49 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7156 W: 1838 L: 1697 D: 3621
Penta | [47, 841, 1676, 952, 62]

LTC (frc)
Elo   | 147.72 +- 23.69 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 466 W: 240 L: 53 D: 173
Penta | [2, 10, 72, 97, 52]

Bench: 7691911