### PR TITLE
Singular Extension: Negative extension: Cut-node

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -426,7 +426,9 @@ namespace rose {
           extension += expected != NodeType::pv && singular_score <= singular_beta - 120;
         }
         // Negative extension
-        else if (tte.score <= alpha) {
+        else if (expected == NodeType::cut) {
+          extension = -2;
+        } else if (tte.score <= alpha) {
           extension = -1;
         }
       }


### PR DESCRIPTION
STC
Elo   | -0.44 +- 3.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.31 (-2.25, 2.89) [0.00, 5.00]
Games | N: 17556 W: 4748 L: 4770 D: 8038
Penta | [380, 2163, 3727, 2115, 393]

LTC
Elo   | 4.12 +- 3.21 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 15704 W: 3958 L: 3772 D: 7974
Penta | [183, 1877, 3578, 1999, 215]

Bench: 5858006