### PR TITLE
QS Futility Pruning

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -644,6 +644,7 @@ namespace rose {
         // QS SEE Pruning
         if (!see::see(position, mv, 0))
           continue;
+
         // QS Futility Pruning
         const Score futility = static_eval + 175;
         if (futility <= alpha && !see::see(position, mv, 1)) {

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -644,6 +644,12 @@ namespace rose {
         // QS SEE Pruning
         if (!see::see(position, mv, 0))
           continue;
+        // QS Futility Pruning
+        const Score futility = static_eval + 175;
+        if (futility <= alpha && !see::see(position, mv, 1)) {
+          best_score = std::max(best_score, futility);
+          continue;
+        }
       }
 
       const Position child_position = make_move(ss, position, mv);


### PR DESCRIPTION
STC
Elo   | 9.39 +- 5.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6030 W: 1721 L: 1558 D: 2751
Penta | [123, 702, 1258, 753, 179]

LTC
Elo   | 5.33 +- 3.87 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10634 W: 2643 L: 2480 D: 5511
Penta | [110, 1271, 2426, 1366, 144]

Bench: 6292671