### PR TITLE
LMR: Reduce less if in check

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -460,6 +460,7 @@ namespace rose {
         reduction -= 1024 * (expected == NodeType::pv);
         reduction -= 128 * history / 1024;
         reduction += 1024 * (expected == NodeType::cut);
+        reduction -= 768 * child_position.is_in_check();
 
         const i32 lmr_depth = std::clamp(new_depth - reduction / 1024, 0, new_depth);
 


### PR DESCRIPTION
STC
Elo   | 4.28 +- 3.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 17454 W: 4878 L: 4663 D: 7913
Penta | [389, 2039, 3660, 2246, 393]

LTC
Elo   | 2.05 +- 1.50 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 69992 W: 17261 L: 16849 D: 35882
Penta | [766, 8498, 16207, 8608, 917]

Bench: 6457238