### PR TITLE
Add new architecture (Kyanite, 010-eleventh)

### DIFF
--- a/src/rose/common.hpp
+++ b/src/rose/common.hpp
@@ -16,7 +16,10 @@ namespace rose {
 
 namespace rose {
 
-#define rose_unused(...) (void)sizeof(__VA_ARGS__)
+  // Silences unused variable warnings
+  template<typename... T>
+  constexpr void rose_unused(const T&...) noexcept {
+  }
 
   using namespace lps::prelude;
 

--- a/src/rose/eval/concepts.hpp
+++ b/src/rose/eval/concepts.hpp
@@ -14,11 +14,13 @@ namespace rose::eval::concepts {
   template<typename T>
   concept Observer =
     requires(T o, const Position& pos, Color stm, PieceType src_ptype, PieceType dst_ptype, PieceType ptype, Square from, Square to, Square sq) {
+      { o.on_king_move(pos, stm, from, to) } -> std::same_as<void>;
       { o.on_add(pos, stm, ptype, sq) } -> std::same_as<void>;
       { o.on_remove(pos, stm, ptype, sq) } -> std::same_as<void>;
       { o.on_mutate(pos, stm, src_ptype, dst_ptype, sq) } -> std::same_as<void>;
       { o.on_move(pos, stm, ptype, from, to) } -> std::same_as<void>;
       { o.on_promote(pos, stm, dst_ptype, from, to) } -> std::same_as<void>;
+      { o.on_finalize(pos) } -> std::same_as<void>;
     };
 
   template<typename T>

--- a/src/rose/eval/nnue/embedded.hpp
+++ b/src/rose/eval/nnue/embedded.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "rose/eval/nnue/jasper.hpp"
+#include "rose/eval/nnue/kyanite.hpp"
 
 namespace rose::eval::nnue {
 
-  using EmbeddedArch = Jasper<256>;
+  using EmbeddedArch = Kyanite<256>;
   using EmbeddedNetwork = EmbeddedArch::Network;
 
   alignas(EmbeddedNetwork) extern const char g_embedded_network_raw[];

--- a/src/rose/eval/nnue/kyanite.hpp
+++ b/src/rose/eval/nnue/kyanite.hpp
@@ -14,19 +14,19 @@
 namespace rose::eval::nnue {
 
   template<usize hl_size>
-  struct Jasper {
+  struct Kyanite {
     inline static constexpr usize input_size = 768;
     inline static constexpr i32 scale = 400;
     inline static constexpr i32 qa = 255;
     inline static constexpr i32 qb = 64;
 
-    inline static auto feature_index(Color perspective, Square sq, PieceType ptype, Color side) -> usize {
+    inline static auto feature_index(const Position& pos, Color perspective, Square sq, PieceType ptype, Color side) -> usize {
       //                          qrb-npk-
       constexpr u32 ptype_lut = 0x43201050;
 
       usize side_index = side.to_index();
       usize ptype_index = (ptype_lut >> (4 * ptype.to_index())) & 0xf;
-      usize square_index = sq.raw;
+      usize square_index = sq.raw ^ (pos.king_sq(perspective).file() >= 4 ? 0b000111 : 0);
 
       if (perspective == Color::black) {
         side_index ^= 1;
@@ -70,10 +70,32 @@ namespace rose::eval::nnue {
       return y * y;
     }
 
+    inline static auto rebuild_accumulator(const Position& pos, const Network& net) -> AccumulatorPair {
+      AccumulatorPair result;
+      result.values.fill(net.accumulator_biases);
+
+      for (u8 i = 0; i < 64; i++) {
+        const Square sq {i};
+        const Place p = pos.place_at(sq);
+
+        if (p.is_empty())
+          continue;
+
+        const usize feature0 = feature_index(pos, Color::white, sq, p.ptype(), p.color());
+        const usize feature1 = feature_index(pos, Color::black, sq, p.ptype(), p.color());
+
+        add(net, result.values[0], feature0);
+        add(net, result.values[1], feature1);
+      }
+
+      return result;
+    }
+
     struct Observer {
     private:
       const Network& m_net;
       AccumulatorPair& m_accum;
+      bool refresh = false;
 
     public:
       Observer(const Network& net, AccumulatorPair& accum) :
@@ -82,17 +104,17 @@ namespace rose::eval::nnue {
       }
 
       auto on_king_move(const Position& pos, Color stm, Square from, Square to) -> void {
-        rose_unused(pos, stm, from, to);
+        refresh = (from.file() >= 4 && to.file() < 4) || (from.file() < 4 && to.file() >= 4);
       }
 
       auto on_add(const Position& pos, Color side, PieceType ptype, Square sq) -> void {
-        add(m_net, m_accum.values[0], feature_index(Color::white, sq, ptype, side));
-        add(m_net, m_accum.values[1], feature_index(Color::black, sq, ptype, side));
+        add(m_net, m_accum.values[0], feature_index(pos, Color::white, sq, ptype, side));
+        add(m_net, m_accum.values[1], feature_index(pos, Color::black, sq, ptype, side));
       }
 
       auto on_remove(const Position& pos, Color side, PieceType ptype, Square sq) -> void {
-        sub(m_net, m_accum.values[0], feature_index(Color::white, sq, ptype, side));
-        sub(m_net, m_accum.values[1], feature_index(Color::black, sq, ptype, side));
+        sub(m_net, m_accum.values[0], feature_index(pos, Color::white, sq, ptype, side));
+        sub(m_net, m_accum.values[1], feature_index(pos, Color::black, sq, ptype, side));
       }
 
       auto on_mutate(const Position& pos, Color side, PieceType src_ptype, PieceType dst_ptype, Square sq) -> void {
@@ -111,7 +133,9 @@ namespace rose::eval::nnue {
       }
 
       auto on_finalize(const Position& pos) -> void {
-        rose_unused(pos);
+        if (refresh) {
+          m_accum = rebuild_accumulator(pos, m_net);
+        }
       }
     };
 
@@ -121,27 +145,6 @@ namespace rose::eval::nnue {
     private:
       StaticVector<AccumulatorPair, max_depth + 6> m_stack;
       const Network& m_net;
-
-      auto rebuild_accumulator(const Position& pos) -> AccumulatorPair {
-        AccumulatorPair result;
-        result.values.fill(m_net.accumulator_biases);
-
-        for (u8 i = 0; i < 64; i++) {
-          const Square sq {i};
-          const Place p = pos.place_at(sq);
-
-          if (p.is_empty())
-            continue;
-
-          const usize feature0 = feature_index(Color::white, sq, p.ptype(), p.color());
-          const usize feature1 = feature_index(Color::black, sq, p.ptype(), p.color());
-
-          add(m_net, result.values[0], feature0);
-          add(m_net, result.values[1], feature1);
-        }
-
-        return result;
-      }
 
       auto evaluate(const Accumulator& us, const Accumulator& them) -> i32 {
         i32 output = 0;
@@ -163,7 +166,7 @@ namespace rose::eval::nnue {
 
       auto reset(const Position& pos) -> void {
         m_stack.clear();
-        m_stack.push_back(rebuild_accumulator(pos));
+        m_stack.push_back(rebuild_accumulator(pos, m_net));
       }
 
       auto push() -> void {
@@ -178,7 +181,7 @@ namespace rose::eval::nnue {
         const Color stm = pos.stm();
         const AccumulatorPair& accumulators = m_stack.back();
 
-        rose_assert(rebuild_accumulator(pos) == accumulators);
+        rose_assert(rebuild_accumulator(pos, m_net) == accumulators);
 
         return evaluate(accumulators.get(stm), accumulators.get(stm.invert()));
       }

--- a/src/rose/eval/null_observer.hpp
+++ b/src/rose/eval/null_observer.hpp
@@ -11,6 +11,10 @@ namespace rose {
 namespace rose::eval {
 
   struct NullObserver {
+    auto on_king_move(const Position& pos, Color stm, Square from, Square to) -> void {
+      rose_unused(pos, stm, from, to);
+    }
+
     auto on_add(const Position& pos, Color side, PieceType ptype, Square sq) -> void {
       rose_unused(pos, side, ptype, sq);
     }
@@ -29,6 +33,10 @@ namespace rose::eval {
 
     auto on_promote(const Position& pos, Color side, PieceType dst_ptype, Square from, Square to) -> void {
       rose_unused(pos, side, dst_ptype, from, to);
+    }
+
+    auto on_finalize(const Position& pos) -> void {
+      rose_unused(pos);
     }
   };
 

--- a/src/rose/position.cpp
+++ b/src/rose/position.cpp
@@ -4,6 +4,7 @@
 #include "rose/board.hpp"
 #include "rose/common.hpp"
 #include "rose/eval/nnue/jasper.hpp"
+#include "rose/eval/nnue/kyanite.hpp"
 #include "rose/geometry.hpp"
 #include "rose/move.hpp"
 #include "rose/movegen.hpp"
@@ -430,6 +431,10 @@ namespace rose {
     const PieceId src_id = src_place.id();
     const PieceId dest_id = dest_place.id();
 
+    if (src_place.ptype() == PieceType::k) {
+      observer.on_king_move(new_pos, m_stm, from, to);
+    }
+
     const auto check_src_castling_rights = [&] {
       new_pos.m_rook_info.unset(m_stm, from);
       if (src_place.ptype() == PieceType::k) {
@@ -586,6 +591,8 @@ namespace rose {
     new_pos.m_ply++;
     new_pos.m_stm = !m_stm;
 
+    observer.on_finalize(new_pos);
+
     rose_assert(new_pos.m_hash == new_pos.calc_hash_slow(),
                 "{} [{:016x}] : {} : {} [{:016x} {:016x}]",
                 to_string(MoveFormat::frc),
@@ -601,6 +608,7 @@ namespace rose {
   template auto Position::move<eval::NullObserver>(Move m, eval::NullObserver observer) const -> Position;
   template auto Position::move<eval::nnue::Jasper<128>::Observer>(Move m, eval::nnue::Jasper<128>::Observer observer) const -> Position;
   template auto Position::move<eval::nnue::Jasper<256>::Observer>(Move m, eval::nnue::Jasper<256>::Observer observer) const -> Position;
+  template auto Position::move<eval::nnue::Kyanite<256>::Observer>(Move m, eval::nnue::Kyanite<256>::Observer observer) const -> Position;
 
   auto Position::null_move() const -> Position {
     Position new_pos = *this;

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -3,6 +3,7 @@
 #include "rose/common.hpp"
 #include "rose/engine_output.hpp"
 #include "rose/eval/nnue/jasper.hpp"
+#include "rose/eval/nnue/kyanite.hpp"
 #include "rose/game.hpp"
 #include "rose/limits.hpp"
 #include "rose/move_picker.hpp"
@@ -732,5 +733,6 @@ namespace rose {
 
   template struct Search<eval::nnue::Jasper<128>::State>;
   template struct Search<eval::nnue::Jasper<256>::State>;
+  template struct Search<eval::nnue::Kyanite<256>::State>;
 
 }  // namespace rose

--- a/src/rose_network.txt
+++ b/src/rose_network.txt
@@ -1,1 +1,1 @@
-009-tenth
+kyanite256-ds20260608-sb100

--- a/src/rose_network.txt
+++ b/src/rose_network.txt
@@ -1,1 +1,1 @@
-kyanite256-ds20260608-sb100
+010-eleventh


### PR DESCRIPTION
(768hm x N) x 2 -> 1; N=256
Datasets: ds20260607, ds20260608
sb100, wdl0.2, 80% DFRC data

FN (standard)
Elo   | -2.90 +- 5.49 (95%)
SPRT  | N=10000 Threads=1 Hash=16MB
LLR   | -2.43 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9460 W: 3142 L: 3221 D: 3097
Penta | [463, 1091, 1701, 1012, 463]

FN (frc)
Elo   | 30.88 +- 9.98 (95%)
SPRT  | N=10000 Threads=1 Hash=16MB
LLR   | 4.56 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3136 W: 1265 L: 987 D: 884
Penta | [133, 277, 579, 337, 242]

STC (standard)
Elo   | 8.31 +- 5.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6400 W: 1811 L: 1658 D: 2931
Penta | [85, 734, 1441, 823, 117]

STC (frc)
Elo   | 58.58 +- 15.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.04 (-2.25, 2.89) [0.00, 5.00]
Games | N: 934 W: 354 L: 198 D: 382
Penta | [10, 83, 165, 159, 50]

LTC (standard)
Elo   | 16.09 +- 8.15 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 2398 W: 703 L: 592 D: 1103
Penta | [23, 249, 561, 326, 40]

LTC (frc)
Elo   | 49.58 +- 14.23 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1016 W: 360 L: 216 D: 440
Penta | [12, 82, 207, 164, 43]

Bench: 6535671