### PR TITLE
Aspiration reduction

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -200,15 +200,21 @@ namespace rose {
         beta = last_score + delta;
       }
 
+      i32 aspiration_reduction = 0;
+
       while (true) {
         m_search_stack = {};
-
         pv.clear();
-        score = search<NodeType::pv, true>(ctrl, m_root, pv, alpha, beta, &m_search_stack[search_stack_offset], 0, depth);
+
+        const i32 aspiration_depth = std::max(1, depth - aspiration_reduction);
+        SearchStack* ss = &m_search_stack[search_stack_offset];
+        score = search<NodeType::pv, true>(ctrl, m_root, pv, alpha, beta, ss, 0, aspiration_depth);
 
         if (score <= alpha) {
+          aspiration_reduction = 0;
           alpha = std::max(score - delta, -score::infinity);
         } else if (score >= beta) {
+          aspiration_reduction = std::min(aspiration_reduction + 1, 3);
           beta = std::min(score + delta, score::infinity);
         } else {
           break;


### PR DESCRIPTION
STC
Elo   | 5.87 +- 4.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10542 W: 2922 L: 2744 D: 4876
Penta | [210, 1225, 2245, 1359, 232]

LTC
Elo   | 4.15 +- 3.22 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 15156 W: 3826 L: 3645 D: 7685
Penta | [148, 1818, 3528, 1873, 211]

Bench: 4904907