### PR TITLE
Update network arch to Jasper<512> (011-twelfth)

### DIFF
--- a/src/rose/eval/nnue/arch.hpp
+++ b/src/rose/eval/nnue/arch.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "rose/eval/nnue/jasper.hpp"
+#include "rose/eval/nnue/kyanite.hpp"
+
+namespace rose::eval::nnue {
+
+  // clang-format off
+#define rose_for_each_arch(x)      \
+  x(jasper128, Jasper<128>)        \
+  x(jasper256, Jasper<256>)        \
+  x(kyanite256, Kyanite<256>)      \
+  x(kyanite512, Kyanite<512>)
+  // clang-format on
+
+}  // namespace rose::eval::nnue

--- a/src/rose/eval/nnue/embedded.hpp
+++ b/src/rose/eval/nnue/embedded.hpp
@@ -4,7 +4,7 @@
 
 namespace rose::eval::nnue {
 
-  using EmbeddedArch = Kyanite<256>;
+  using EmbeddedArch = Kyanite<512>;
   using EmbeddedNetwork = EmbeddedArch::Network;
 
   alignas(EmbeddedNetwork) extern const char g_embedded_network_raw[];

--- a/src/rose/position.cpp
+++ b/src/rose/position.cpp
@@ -3,8 +3,7 @@
 #include "rose/bitboard.hpp"
 #include "rose/board.hpp"
 #include "rose/common.hpp"
-#include "rose/eval/nnue/jasper.hpp"
-#include "rose/eval/nnue/kyanite.hpp"
+#include "rose/eval/nnue/arch.hpp"
 #include "rose/geometry.hpp"
 #include "rose/move.hpp"
 #include "rose/movegen.hpp"
@@ -606,9 +605,9 @@ namespace rose {
   }
 
   template auto Position::move<eval::NullObserver>(Move m, eval::NullObserver observer) const -> Position;
-  template auto Position::move<eval::nnue::Jasper<128>::Observer>(Move m, eval::nnue::Jasper<128>::Observer observer) const -> Position;
-  template auto Position::move<eval::nnue::Jasper<256>::Observer>(Move m, eval::nnue::Jasper<256>::Observer observer) const -> Position;
-  template auto Position::move<eval::nnue::Kyanite<256>::Observer>(Move m, eval::nnue::Kyanite<256>::Observer observer) const -> Position;
+#define rose_position_move_template(e, T)                                                                                                            \
+  template auto Position::move<eval::nnue::T::Observer>(Move m, eval::nnue::T::Observer observer) const -> Position;
+  rose_for_each_arch(rose_position_move_template);
 
   auto Position::null_move() const -> Position {
     Position new_pos = *this;

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -200,15 +200,21 @@ namespace rose {
         beta = last_score + delta;
       }
 
+      i32 aspiration_reduction = 0;
+
       while (true) {
         m_search_stack = {};
-
         pv.clear();
-        score = search<NodeType::pv, true>(ctrl, m_root, pv, alpha, beta, &m_search_stack[search_stack_offset], 0, depth);
+
+        const i32 aspiration_depth = std::max(1, depth - aspiration_reduction);
+        SearchStack* ss = &m_search_stack[search_stack_offset];
+        score = search<NodeType::pv, true>(ctrl, m_root, pv, alpha, beta, ss, 0, aspiration_depth);
 
         if (score <= alpha) {
+          aspiration_reduction = 0;
           alpha = std::max(score - delta, -score::infinity);
         } else if (score >= beta) {
+          aspiration_reduction = std::min(aspiration_reduction + 1, 3);
           beta = std::min(score + delta, score::infinity);
         } else {
           break;

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -2,8 +2,7 @@
 
 #include "rose/common.hpp"
 #include "rose/engine_output.hpp"
-#include "rose/eval/nnue/jasper.hpp"
-#include "rose/eval/nnue/kyanite.hpp"
+#include "rose/eval/nnue/arch.hpp"
 #include "rose/game.hpp"
 #include "rose/limits.hpp"
 #include "rose/move_picker.hpp"
@@ -738,8 +737,7 @@ namespace rose {
     ss->conthist = nullptr;
   }
 
-  template struct Search<eval::nnue::Jasper<128>::State>;
-  template struct Search<eval::nnue::Jasper<256>::State>;
-  template struct Search<eval::nnue::Kyanite<256>::State>;
+#define rose_search_template(e, T) template struct Search<eval::nnue::T::State>;
+  rose_for_each_arch(rose_search_template);
 
 }  // namespace rose

--- a/src/rose_network.txt
+++ b/src/rose_network.txt
@@ -1,1 +1,1 @@
-010-eleventh
+kyanite512-20260613-sb120

--- a/src/rose_network.txt
+++ b/src/rose_network.txt
@@ -1,1 +1,1 @@
-kyanite512-20260613-sb120
+011-twelfth


### PR DESCRIPTION
Expand HL from 256 to 512.
Uses datasets 20260611 and 20260613 (approx 1B positions).
WDL0.2, SB120, 80% DFRC.

Est. CCRL Blitz Elo: ~3500

FN (standard)
Elo   | 84.12 +- 10.13 (95%)
SPRT  | N=10000 Threads=1 Hash=16MB
LLR   | 11.28 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2758 W: 1249 L: 594 D: 915
Penta | [48, 178, 468, 441, 244]

FN (frc)
Elo   | 88.54 +- 10.65 (95%)
SPRT  | N=10000 Threads=1 Hash=16MB
LLR   | 11.49 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2786 W: 1329 L: 634 D: 823
Penta | [58, 177, 465, 398, 295]

STC (standard)
Elo   | 39.53 +- 11.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.09 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1218 W: 400 L: 262 D: 556
Penta | [9, 103, 271, 193, 33]

STC (frc)
Elo   | 68.45 +- 15.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.55 (-2.25, 2.89) [0.00, 5.00]
Games | N: 946 W: 372 L: 188 D: 386
Penta | [10, 68, 176, 166, 53]

LTC (standard)
Elo   | 49.31 +- 12.34 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 3.08 (-2.25, 2.89) [0.00, 5.00]
Games | N: 908 W: 302 L: 174 D: 432
Penta | [2, 66, 198, 178, 10]

LTC (frc)
Elo   | 73.78 +- 16.07 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 5.00]
Games | N: 650 W: 245 L: 109 D: 296
Penta | [0, 39, 137, 123, 26]

Bench: 4202396