### PR TITLE
More Singular Extensions (reduce depth guard from 9 to 7)

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -411,7 +411,7 @@ namespace rose {
 
       i32 extension = 0;
       // Singular Extensions
-      if (!is_root && depth >= 9 && mv == tte.move && !excluded && tte.depth >= depth - 3 && tte.bound.is_pv_or_cut()) {
+      if (!is_root && depth >= 7 && mv == tte.move && !excluded && tte.depth >= depth - 3 && tte.bound.is_pv_or_cut()) {
         const Score singular_beta = std::max(score::min_score, tte.score - 2 * depth);
         const i32 singular_depth = depth / 2;
 


### PR DESCRIPTION
STC
Elo   | 5.72 +- 4.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10632 W: 2899 L: 2724 D: 5009
Penta | [177, 1251, 2339, 1318, 231]

LTC
Elo   | 5.07 +- 3.67 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10698 W: 2633 L: 2477 D: 5588
Penta | [68, 1281, 2526, 1375, 99]

Bench: 7318927