### PR TITLE
Update architecture to Kyanite<768> (013-fourteenth)

### DIFF
--- a/src/rose/eval/nnue/arch.hpp
+++ b/src/rose/eval/nnue/arch.hpp
@@ -10,7 +10,8 @@ namespace rose::eval::nnue {
   x(jasper128, Jasper<128>)        \
   x(jasper256, Jasper<256>)        \
   x(kyanite256, Kyanite<256>)      \
-  x(kyanite512, Kyanite<512>)
+  x(kyanite512, Kyanite<512>)      \
+  x(kyanite768, Kyanite<768>)
   // clang-format on
 
 }  // namespace rose::eval::nnue

--- a/src/rose/eval/nnue/embedded.hpp
+++ b/src/rose/eval/nnue/embedded.hpp
@@ -4,7 +4,7 @@
 
 namespace rose::eval::nnue {
 
-  using EmbeddedArch = Kyanite<512>;
+  using EmbeddedArch = Kyanite<768>;
   using EmbeddedNetwork = EmbeddedArch::Network;
 
   alignas(EmbeddedNetwork) extern const char g_embedded_network_raw[];

--- a/src/rose_network.txt
+++ b/src/rose_network.txt
@@ -1,1 +1,1 @@
-012-thirteenth
+013-fourteenth


### PR DESCRIPTION
Increase HL size from 512 to 768.
Uses dataset 20260613to17 (approximately >1 billion positions).

FN (standard)
Elo   | 41.47 +- 10.54 (95%)
SPRT  | N=10000 Threads=1 Hash=16MB
LLR   | 5.22 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2500 W: 984 L: 687 D: 829
Penta | [78, 212, 456, 343, 161]

FN (frc)
Elo   | 48.73 +- 14.48 (95%)
SPRT  | N=10000 Threads=1 Hash=16MB
LLR   | 3.48 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1500 W: 634 L: 425 D: 441
Penta | [54, 123, 254, 198, 121]

STC (standard)
Elo   | 15.92 +- 7.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2948 W: 834 L: 699 D: 1415
Penta | [27, 332, 645, 419, 51]

STC (frc)
Elo   | 24.28 +- 9.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2064 W: 637 L: 493 D: 934
Penta | [28, 226, 421, 288, 69]

LTC (standard)
Elo   | 12.09 +- 6.14 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3422 W: 912 L: 793 D: 1717
Penta | [9, 367, 855, 456, 24]

LTC (frc)
Elo   | 23.25 +- 9.07 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1856 W: 515 L: 391 D: 950
Penta | [12, 186, 421, 284, 25]

Bench: 5631238