### PR TITLE
Bias beta on aspiration fail-low

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -227,7 +227,7 @@ namespace rose {
 
         if (score <= alpha) {
           aspiration_reduction = 0;
-          beta = (alpha * 5 + beta * 11) / 16;
+          beta = (alpha + beta) / 2;
           alpha = std::max(score - delta, -score::infinity);
         } else if (score >= beta) {
           aspiration_reduction = std::min(aspiration_reduction + 1, 3);

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -227,6 +227,7 @@ namespace rose {
 
         if (score <= alpha) {
           aspiration_reduction = 0;
+          beta = (alpha * 5 + beta * 11) / 16;
           alpha = std::max(score - delta, -score::infinity);
         } else if (score >= beta) {
           aspiration_reduction = std::min(aspiration_reduction + 1, 3);


### PR DESCRIPTION
STC
Elo   | 4.34 +- 3.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 14878 W: 3915 L: 3729 D: 7234
Penta | [195, 1790, 3312, 1918, 224]

LTC
Elo   | 12.86 +- 6.27 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3298 W: 823 L: 701 D: 1774
Penta | [9, 350, 825, 440, 25]

Bench: 5657399