### PR TITLE
Internal iterative deepening

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -309,6 +309,7 @@ namespace rose {
     const Bitboard enemy_threatened = position.attack_table(!stm).bitboard_any();
 
     const tt::LookupResult tte = tt_load(position, ply);
+    Move hint_move = tte.move;
 
     // Transposition Table Cutoffs
     if (expected != NodeType::pv && !excluded && tte.is_some() && tte.depth >= depth && [&] {
@@ -373,7 +374,15 @@ namespace rose {
       }
     }
 
-    MovePicker moves {m_sd, position, ss, tte.move};
+    // Internal iterative deepening
+    if (expected == NodeType::pv && depth >= 8 && tte.is_none() && !excluded) {
+      const i32 iid_depth = (depth * 3 - 7) / 4;
+
+      search<NodeType::cut>(ctrl, position, pv, alpha, alpha + 1, ss, ply, iid_depth);
+      hint_move = tt_load(position, ply).move;
+    }
+
+    MovePicker moves {m_sd, position, ss, hint_move};
 
     MoveList fail_low_quiets;
     MoveList fail_low_noisies;

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -378,7 +378,7 @@ namespace rose {
     if (expected == NodeType::pv && depth >= 8 && tte.is_none() && !excluded) {
       const i32 iid_depth = depth - 3;
 
-      search<NodeType::pv>(ctrl, position, pv, alpha, alpha + 1, ss, ply, iid_depth);
+      search<NodeType::pv>(ctrl, position, pv, alpha, beta, ss, ply, iid_depth);
       hint_move = tt_load(position, ply).move;
     }
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -375,8 +375,8 @@ namespace rose {
     }
 
     // Internal iterative deepening
-    if (expected == NodeType::pv && depth >= 8 && tte.is_none() && !excluded) {
-      const i32 iid_depth = depth - 3;
+    if (!is_root && expected == NodeType::pv && depth >= 8 && tte.is_none() && !excluded) {
+      const i32 iid_depth = (768 * depth - 1536) / 1024;
 
       search<NodeType::pv>(ctrl, position, pv, alpha, beta, ss, ply, iid_depth);
       hint_move = tt_load(position, ply).move;

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -220,6 +220,7 @@ namespace rose {
         m_search_stack = {};
         pv.clear();
         m_nmr_ply = std::nullopt;
+        m_in_iid = false;
 
         const i32 aspiration_depth = std::max(1, depth - aspiration_reduction);
         SearchStack* ss = &m_search_stack[search_stack_offset];
@@ -378,8 +379,15 @@ namespace rose {
     if (!is_root && expected == NodeType::pv && depth >= 8 && hint_move.is_none() && !excluded) {
       const i32 iid_depth = (768 * depth - 1536) / 1024;
 
+      const bool prev_in_iid = m_in_iid;
+      m_in_iid = true;
       search<NodeType::pv>(ctrl, position, pv, alpha, beta, ss, ply, iid_depth);
-      hint_move = tt_load(position, ply).move;
+      m_in_iid = prev_in_iid;
+
+      const auto iid_tte = tt_load(position, ply);
+      hint_move = iid_tte.move;
+      if (m_in_iid && iid_tte.depth >= depth)
+        return iid_tte.score;
     }
 
     MovePicker moves {m_sd, position, ss, hint_move};

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -376,7 +376,7 @@ namespace rose {
 
     // Internal iterative deepening
     if (expected == NodeType::pv && depth >= 8 && tte.is_none() && !excluded) {
-      const i32 iid_depth = (depth * 3 - 7) / 4;
+      const i32 iid_depth = depth - 3;
 
       search<NodeType::pv>(ctrl, position, pv, alpha, alpha + 1, ss, ply, iid_depth);
       hint_move = tt_load(position, ply).move;

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -375,7 +375,7 @@ namespace rose {
     }
 
     // Internal iterative deepening
-    if (!is_root && expected == NodeType::pv && depth >= 8 && tte.is_none() && !excluded) {
+    if (!is_root && expected == NodeType::pv && depth >= 8 && hint_move.is_none() && !excluded) {
       const i32 iid_depth = (768 * depth - 1536) / 1024;
 
       search<NodeType::pv>(ctrl, position, pv, alpha, beta, ss, ply, iid_depth);

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -378,7 +378,7 @@ namespace rose {
     if (expected == NodeType::pv && depth >= 8 && tte.is_none() && !excluded) {
       const i32 iid_depth = (depth * 3 - 7) / 4;
 
-      search<NodeType::cut>(ctrl, position, pv, alpha, alpha + 1, ss, ply, iid_depth);
+      search<NodeType::pv>(ctrl, position, pv, alpha, alpha + 1, ss, ply, iid_depth);
       hint_move = tt_load(position, ply).move;
     }
 

--- a/src/rose/search.hpp
+++ b/src/rose/search.hpp
@@ -137,6 +137,7 @@ namespace rose {
 
     SearchData m_sd;
     std::optional<i32> m_nmr_ply;
+    bool m_in_iid = false;
 
   public:
     template<typename Network>


### PR DESCRIPTION
STC (fail)
Elo   | -0.19 +- 2.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.35 (-2.25, 2.89) [0.00, 5.00]
Games | N: 20144 W: 5073 L: 5084 D: 9987
Penta | [301, 2430, 4584, 2493, 264]

LTC (pass)
Elo   | 5.58 +- 3.87 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8962 W: 2156 L: 2012 D: 4794
Penta | [42, 1025, 2235, 1105, 74]

LTC SMP (incomplete)
Elo   | 1.30 +- 3.26 (95%)
SPRT  | 40.0+0.40s Threads=4 Hash=128MB
LLR   | 0.01 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11736 W: 2745 L: 2701 D: 6290
Penta | [39, 1396, 2958, 1432, 43]

Bench: 5861842