### PR TITLE
NMR: Use next expected node type instead of assuming all node

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -351,7 +351,7 @@ namespace rose {
       }
 
       // Null move reductions
-      if (depth >= 4 && m_nmr_ply != ply && ss[-1].move.is_some() && static_eval >= beta) {
+      if (expected == NodeType::cut && depth >= 4 && m_nmr_ply != ply && ss[-1].move.is_some() && static_eval >= beta) {
         const i32 reduction = 4 + depth / 3;
 
         const Position null_position = make_null_move(ss, position);

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -351,11 +351,11 @@ namespace rose {
       }
 
       // Null move reductions
-      if (expected == NodeType::cut && depth >= 4 && m_nmr_ply != ply && ss[-1].move.is_some() && static_eval >= beta) {
+      if (depth >= 4 && m_nmr_ply != ply && ss[-1].move.is_some() && static_eval >= beta) {
         const i32 reduction = 4 + depth / 3;
 
         const Position null_position = make_null_move(ss, position);
-        const Score null_score = -search<NodeType::all>(ctrl, null_position, pv, -beta, -beta + 1, ss + 1, ply + 1, depth - reduction);
+        const Score null_score = -search<expected.next()>(ctrl, null_position, pv, -beta, -beta + 1, ss + 1, ply + 1, depth - reduction);
         unmake_move(ss);
 
         if (m_shared.stopping)


### PR DESCRIPTION
LTC non-reg
Elo   | 0.69 +- 2.71 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 18498 W: 4335 L: 4298 D: 9865
Penta | [105, 2252, 4526, 2233, 133]

Bench: 5994049