### PR TITLE
TM: Score Stability

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -203,6 +203,7 @@ namespace rose {
     m_evaluation.reset(m_root);
 
     i32 pv_stability = 0;
+    i32 score_stability = 0;
 
     for (i32 depth = 1; depth < max_depth; depth++) {
       Line pv {};
@@ -254,12 +255,18 @@ namespace rose {
         pv_stability = 0;
       }
 
+      if (std::abs(last_score - score) < 25) {
+        score_stability++;
+      } else {
+        score_stability = 0;
+      }
+
       last_score = score;
       last_pv = pv;
       last_depth = depth;
 
       if (is_main_thread()) {
-        const f32 time_multiplier = std::clamp(1.0 - pv_stability * 0.05, 0.7, 1.0);
+        const f32 time_multiplier = std::clamp(1.0 - pv_stability * 0.05, 0.7, 1.0) * std::clamp(1.0 - score_stability * 0.05, 0.7, 1.0);
 
         if (ctrl.check_soft_termination(stats(), depth, time_multiplier))
           break;


### PR DESCRIPTION
STC
Elo   | 5.07 +- 3.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11176 W: 2866 L: 2703 D: 5607
Penta | [121, 1271, 2666, 1384, 146]

LTC
Elo   | 2.49 +- 2.00 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 5.00]
Games | N: 32470 W: 7581 L: 7348 D: 17541
Penta | [153, 3788, 8165, 3931, 198]

Bench: 5994049