### PR TITLE
LMR: Extend LMR reduced search by one in PV nodes

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -523,7 +523,7 @@ namespace rose {
         reduction += 1024 * (expected == NodeType::cut);
         reduction -= 768 * child_position.is_in_check();
 
-        const i32 lmr_depth = std::clamp(new_depth - reduction / 1024, 0, new_depth);
+        const i32 lmr_depth = std::clamp(new_depth - reduction / 1024, 0, new_depth) + (expected == NodeType::pv);
 
         score = -search<expected.next()>(ctrl, child_position, child_pv, -alpha - 1, -alpha, ss + 1, ply + 1, lmr_depth);
 


### PR DESCRIPTION
STC
Elo   | 6.98 +- 4.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7566 W: 1929 L: 1777 D: 3860
Penta | [87, 884, 1720, 974, 118]

LTC
Elo   | 10.14 +- 5.55 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4420 W: 1063 L: 934 D: 2423
Penta | [22, 487, 1074, 594, 33]

Bench: 7422976