### PR TITLE
Check Evasions in QS

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -696,7 +696,8 @@ namespace rose {
     alpha = std::max(alpha, best_score);
 
     MovePicker moves {m_sd, position, ss, Move::none()};
-    moves.skip_quiet();
+    if (!is_in_check)
+      moves.skip_quiet();
 
     Move best_move = Move::none();
     NodeType actual_node_type = NodeType::all;
@@ -742,6 +743,10 @@ namespace rose {
           }
         }
       }
+
+      // Limit evasions
+      if (is_in_check && !score::is_loss(best_score))
+        moves.skip_quiet();
     }
 
     return best_score;


### PR DESCRIPTION
STC
Elo   | 9.68 +- 5.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4990 W: 1278 L: 1139 D: 2573
Penta | [40, 586, 1146, 641, 82]

LTC
Elo   | 6.06 +- 4.04 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8080 W: 1920 L: 1779 D: 4381
Penta | [43, 903, 2012, 1034, 48]

Bench: 7328768