### PR TITLE
Extract hash management from Position

### DIFF
--- a/src/rose/cmd/perft.cpp
+++ b/src/rose/cmd/perft.cpp
@@ -24,6 +24,8 @@ namespace rose::perft {
 
     for (Move m : moves) {
       const Position new_position = position.move(m);
+      rose_assert(new_position.calc_hash_slow() == position.hash_after(position.calc_hash_slow(), m));
+
       const u64 child = core<false, bulk>(new_position, depth - 1);
       if constexpr (print) {
         fmt::print("{}: {}\n", m.to_string(MoveFormat::frc), child);

--- a/src/rose/game.hpp
+++ b/src/rose/game.hpp
@@ -11,9 +11,9 @@ namespace rose {
 
   struct Game {
   private:
-    std::vector<Position> m_position_stack;
     std::vector<Move> m_move_stack;
     std::vector<Hash> m_hash_stack;
+    std::vector<Position> m_position_stack;
 
   public:
     Game() {
@@ -49,18 +49,18 @@ namespace rose {
     }
 
     auto set_position(const Position& new_pos) -> void {
-      m_position_stack.clear();
       m_move_stack.clear();
       m_hash_stack.clear();
+      m_position_stack.clear();
 
+      m_hash_stack.push_back(new_pos.calc_hash_slow());
       m_position_stack.push_back(new_pos);
-      m_hash_stack.push_back(new_pos.hash());
     }
 
     auto move(Move m) -> void {
-      m_position_stack.emplace_back(m_position_stack.back().move(m));
       m_move_stack.push_back(m);
-      m_hash_stack.push_back(m_position_stack.back().hash());
+      m_hash_stack.push_back(m_position_stack.back().hash_after(m_hash_stack.back(), m));
+      m_position_stack.emplace_back(m_position_stack.back().move(m));
     }
 
     auto unmove() -> void {

--- a/src/rose/position.cpp
+++ b/src/rose/position.cpp
@@ -508,8 +508,6 @@ namespace rose {
       new_pos.m_hash ^= hash::move_piece(from, to, src_place);
 
       new_pos.m_50mr = 0;
-      check_src_castling_rights();
-      check_dest_castling_rights();
     };
 
     const auto castle = [&](u8 king_dest_file, u8 rook_dest_file) {
@@ -636,6 +634,130 @@ namespace rose {
                 new_pos.calc_hash_slow());
 
     return new_pos;
+  }
+
+  auto Position::hash_after(Hash prev, Move m) const -> Hash {
+    Hash new_hash = prev;
+    RookInfo new_rook_info = m_rook_info;
+
+    if (m_enpassant.is_valid()) {
+      new_hash ^= hash::enpassant_table[m_enpassant.file()];
+    }
+
+    const Square from = m.from();
+    const Square to = m.to();
+    const Place src_place = m_board[from];
+    const Place dest_place = m_board[to];
+
+    const auto check_src_castling_rights = [&] {
+      new_rook_info.unset(m_stm, from);
+      if (src_place.ptype() == PieceType::k) {
+        new_rook_info.clear(m_stm);
+      }
+    };
+
+    const auto check_dest_castling_rights = [&] {
+      new_rook_info.unset(!m_stm, to);
+    };
+
+    const auto normal = [&] {
+      new_hash ^= hash::move_piece(from, to, src_place);
+      check_src_castling_rights();
+    };
+
+    const auto cap_normal = [&] {
+      new_hash ^= hash::remove_piece(to, dest_place);
+      new_hash ^= hash::move_piece(from, to, src_place);
+      check_src_castling_rights();
+      check_dest_castling_rights();
+    };
+
+    const auto promo = [&](auto ptype) {
+      new_hash ^= hash::promo(from, to, m_stm, decltype(ptype)::value);
+    };
+
+    const auto cap_promo = [&](auto ptype) {
+      new_hash ^= hash::remove_piece(to, dest_place);
+      new_hash ^= hash::promo(from, to, m_stm, decltype(ptype)::value);
+      check_dest_castling_rights();
+    };
+
+    const auto double_push = [&] {
+      new_hash ^= hash::move_piece(from, to, src_place);
+      const Square new_enpassant {narrow_cast<u8>((from.raw + to.raw) >> 1)};
+      new_hash ^= hash::enpassant_table[new_enpassant.file()];
+    };
+
+    const auto enpassant = [&] {
+      const Square victim = Square::from_file_and_rank(to.file(), from.rank());
+      new_hash ^= hash::remove_piece(victim, !m_stm, PieceType::p);
+      new_hash ^= hash::move_piece(from, to, src_place);
+    };
+
+    const auto castle = [&](u8 king_dest_file, u8 rook_dest_file) {
+      const Square king_dest {narrow_cast<u8>((from.raw & 0x38) | king_dest_file)};
+      const Square rook_dest {narrow_cast<u8>((from.raw & 0x38) | rook_dest_file)};
+      const Square king_src = m.from();
+      const Square rook_src = m.to();
+
+      new_hash ^= hash::move_piece(king_src, king_dest, m_stm, PieceType::k);
+      new_hash ^= hash::move_piece(rook_src, rook_dest, m_stm, PieceType::r);
+
+      new_rook_info.clear(m_stm);
+    };
+
+#define MF(x) (static_cast<int>(MoveFlags::x) >> 12)
+    switch (static_cast<int>(m.flags()) >> 12) {
+    case MF(normal):
+      normal();
+      break;
+    case MF(double_push):
+      double_push();
+      break;
+    case MF(castle_aside):
+      castle(2, 3);
+      break;
+    case MF(castle_hside):
+      castle(6, 5);
+      break;
+    case MF(promo_q):
+      promo(std::integral_constant<PieceType, PieceType::q> {});
+      break;
+    case MF(promo_n):
+      promo(std::integral_constant<PieceType, PieceType::n> {});
+      break;
+    case MF(promo_r):
+      promo(std::integral_constant<PieceType, PieceType::r> {});
+      break;
+    case MF(promo_b):
+      promo(std::integral_constant<PieceType, PieceType::b> {});
+      break;
+    case MF(cap_normal):
+      cap_normal();
+      break;
+    case MF(enpassant):
+      enpassant();
+      break;
+    case MF(cap_promo_q):
+      cap_promo(std::integral_constant<PieceType, PieceType::q> {});
+      break;
+    case MF(cap_promo_n):
+      cap_promo(std::integral_constant<PieceType, PieceType::n> {});
+      break;
+    case MF(cap_promo_r):
+      cap_promo(std::integral_constant<PieceType, PieceType::r> {});
+      break;
+    case MF(cap_promo_b):
+      cap_promo(std::integral_constant<PieceType, PieceType::b> {});
+      break;
+    }
+#undef MF
+
+    new_hash ^= hash::castle_table[m_rook_info.to_index()];
+    new_hash ^= hash::castle_table[new_rook_info.to_index()];
+    new_hash ^= hash::move;
+
+    return new_hash;
   }
 
   auto Position::calc_hash_slow() const -> Hash {

--- a/src/rose/position.cpp
+++ b/src/rose/position.cpp
@@ -399,9 +399,11 @@ namespace rose {
 
   auto Position::is_repetition(const std::vector<u64>& hash_stack, usize hash_waterline) const -> bool {
     const int height = static_cast<int>(hash_stack.size()) - 1;
+    const Hash current_hash = hash_stack[height];
+
     usize clones = 0;
     for (int i = height - 4; i >= 0; i -= 2) {
-      if (hash_stack[i] == m_hash) {
+      if (hash_stack[i] == current_hash) {
         const usize clone_limit = i < hash_waterline ? 2 : 1;
         clones++;
         if (clones >= clone_limit)
@@ -418,10 +420,7 @@ namespace rose {
     new_pos.m_cached_pinned = {};
     new_pos.m_cached_masked_attack_table = {};
 
-    if (new_pos.m_enpassant.is_valid()) {
-      new_pos.m_hash ^= hash::enpassant_table[new_pos.m_enpassant.file()];
-      new_pos.m_enpassant = Square::invalid();
-    }
+    new_pos.m_enpassant = Square::invalid();
 
     const Square from = m.from();
     const Square to = m.to();
@@ -448,7 +447,6 @@ namespace rose {
     const auto normal = [&] {
       new_pos.move_piece<false>(m_stm, from, to, src_id, src_place.ptype(), src_place.ptype());
       observer.on_move(*this, m_stm, src_place.ptype(), from, to);
-      new_pos.m_hash ^= hash::move_piece(from, to, src_place);
       if (src_place.ptype() != PieceType::p) {
         new_pos.m_50mr++;
       } else {
@@ -462,8 +460,6 @@ namespace rose {
       observer.on_remove(*this, !m_stm, dest_place.ptype(), to);
       new_pos.move_piece<true>(m_stm, from, to, src_id, src_place.ptype(), src_place.ptype());
       observer.on_move(*this, m_stm, src_place.ptype(), from, to);
-      new_pos.m_hash ^= hash::remove_piece(to, dest_place);
-      new_pos.m_hash ^= hash::move_piece(from, to, src_place);
       new_pos.m_50mr = 0;
       check_src_castling_rights();
       check_dest_castling_rights();
@@ -472,7 +468,6 @@ namespace rose {
     const auto promo = [&](auto ptype) {
       new_pos.move_piece<false>(m_stm, from, to, src_id, src_place.ptype(), decltype(ptype)::value);
       observer.on_promote(*this, m_stm, decltype(ptype)::value, from, to);
-      new_pos.m_hash ^= hash::promo(from, to, m_stm, decltype(ptype)::value);
       new_pos.m_50mr = 0;
     };
 
@@ -481,8 +476,6 @@ namespace rose {
       observer.on_remove(*this, !m_stm, dest_place.ptype(), to);
       new_pos.move_piece<true>(m_stm, from, to, src_id, src_place.ptype(), decltype(ptype)::value);
       observer.on_promote(*this, m_stm, decltype(ptype)::value, from, to);
-      new_pos.m_hash ^= hash::remove_piece(to, dest_place);
-      new_pos.m_hash ^= hash::promo(from, to, m_stm, decltype(ptype)::value);
       new_pos.m_50mr = 0;
       check_dest_castling_rights();
     };
@@ -490,10 +483,8 @@ namespace rose {
     const auto double_push = [&] {
       new_pos.move_piece<false>(m_stm, from, to, src_id, src_place.ptype(), src_place.ptype());
       observer.on_move(*this, m_stm, src_place.ptype(), from, to);
-      new_pos.m_hash ^= hash::move_piece(from, to, src_place);
       new_pos.m_50mr = 0;
       new_pos.m_enpassant = Square {narrow_cast<u8>((from.raw + to.raw) >> 1)};
-      new_pos.m_hash ^= hash::enpassant_table[new_pos.m_enpassant.file()];
     };
 
     const auto enpassant = [&] {
@@ -504,8 +495,6 @@ namespace rose {
       observer.on_remove(*this, !m_stm, PieceType::p, victim);
       new_pos.move_piece<false>(m_stm, from, to, src_id, src_place.ptype(), src_place.ptype());
       observer.on_move(*this, m_stm, src_place.ptype(), from, to);
-      new_pos.m_hash ^= hash::remove_piece(victim, !m_stm, PieceType::p);
-      new_pos.m_hash ^= hash::move_piece(from, to, src_place);
 
       new_pos.m_50mr = 0;
     };
@@ -526,9 +515,6 @@ namespace rose {
       observer.on_add(*this, m_stm, PieceType::k, king_dest);
       new_pos.add_piece<true>(m_stm, rook_dest, rook_id, PieceType::r);
       observer.on_add(*this, m_stm, PieceType::r, rook_dest);
-
-      new_pos.m_hash ^= hash::move_piece(king_src, king_dest, m_stm, PieceType::k);
-      new_pos.m_hash ^= hash::move_piece(rook_src, rook_dest, m_stm, PieceType::r);
 
       new_pos.m_50mr++;
       new_pos.m_rook_info.clear(m_stm);
@@ -581,23 +567,10 @@ namespace rose {
     }
 #undef MF
 
-    new_pos.m_hash ^= hash::castle_table[m_rook_info.to_index()];
-    new_pos.m_hash ^= hash::castle_table[new_pos.m_rook_info.to_index()];
-    new_pos.m_hash ^= hash::move;
-
     new_pos.m_ply++;
     new_pos.m_stm = !m_stm;
 
     observer.on_finalize(new_pos);
-
-    rose_assert(new_pos.m_hash == new_pos.calc_hash_slow(),
-                "{} [{:016x}] : {} : {} [{:016x} {:016x}]",
-                to_string(MoveFormat::frc),
-                m_hash,
-                m.to_string(MoveFormat::frc),
-                new_pos.to_string(MoveFormat::frc),
-                new_pos.m_hash,
-                new_pos.calc_hash_slow());
 
     return new_pos;
   }
@@ -614,24 +587,13 @@ namespace rose {
     new_pos.m_cached_masked_attack_table = {};
 
     if (new_pos.m_enpassant.is_valid()) {
-      new_pos.m_hash ^= hash::enpassant_table[new_pos.m_enpassant.file()];
       new_pos.m_enpassant = Square::invalid();
     }
 
     new_pos.m_50mr++;
 
-    new_pos.m_hash ^= hash::move;
-
     new_pos.m_ply++;
     new_pos.m_stm = !m_stm;
-
-    rose_assert(new_pos.m_hash == new_pos.calc_hash_slow(),
-                "{} [{:016x}] : {} : (null move) [{:016x} {:016x}]",
-                to_string(MoveFormat::frc),
-                m_hash,
-                new_pos.to_string(MoveFormat::frc),
-                new_pos.m_hash,
-                new_pos.calc_hash_slow());
 
     return new_pos;
   }
@@ -1022,7 +984,6 @@ namespace rose {
     }
 
     result.m_attack_table = result.calc_attacks_slow();
-    result.m_hash = result.calc_hash_slow();
 
     return result;
   }

--- a/src/rose/position.cpp
+++ b/src/rose/position.cpp
@@ -760,6 +760,18 @@ namespace rose {
     return new_hash;
   }
 
+  auto Position::hash_after_null_move(Hash prev) const -> Hash {
+    Hash new_hash = prev;
+
+    if (m_enpassant.is_valid()) {
+      new_hash ^= hash::enpassant_table[m_enpassant.file()];
+    }
+
+    new_hash ^= hash::move;
+
+    return new_hash;
+  }
+
   auto Position::calc_hash_slow() const -> Hash {
     Hash result = 0;
     for (u8 sq = 0; sq < 64; sq++)

--- a/src/rose/position.hpp
+++ b/src/rose/position.hpp
@@ -259,6 +259,7 @@ namespace rose {
       return move(m, eval::NullObserver {});
     }
 
+    auto hash_after(Hash prev, Move m) const -> Hash;
     auto calc_hash_slow() const -> Hash;
 
     auto pin_info() const -> std::tuple<const std::array<PieceMask, 64>&, Bitboard>;

--- a/src/rose/position.hpp
+++ b/src/rose/position.hpp
@@ -260,6 +260,7 @@ namespace rose {
     }
 
     auto hash_after(Hash prev, Move m) const -> Hash;
+    auto hash_after_null_move(Hash prev) const -> Hash;
     auto calc_hash_slow() const -> Hash;
 
     auto pin_info() const -> std::tuple<const std::array<PieceMask, 64>&, Bitboard>;

--- a/src/rose/position.hpp
+++ b/src/rose/position.hpp
@@ -130,7 +130,6 @@ namespace rose {
     Byteboard m_board {};
     std::array<PieceList<Square>, 2> m_piece_list_sq {};
     std::array<PieceList<PieceType>, 2> m_piece_list_ptype {};
-    u64 m_hash {};
     RookInfo m_rook_info {};
     u16 m_50mr {};
     u16 m_ply {};
@@ -173,10 +172,6 @@ namespace rose {
 
     constexpr auto piece_list_type(Color color) const -> PieceList<PieceType> {
       return m_piece_list_ptype[color.to_index()];
-    }
-
-    constexpr auto hash() const -> Hash {
-      return m_hash;
     }
 
     constexpr auto rook_info() const -> RookInfo {

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -148,6 +148,8 @@ namespace rose {
         m_hash_stack = g.hash_stack();
         m_hash_waterline = std::max<usize>(1, m_hash_stack.size()) - 1;
 
+        rose_assert(m_hash_stack.back() == m_root.calc_hash_slow());
+
         const auto ctrl = is_main_thread() ? calc_ctrl(m_shared.search_start_time, m_shared.search_main_limits, m_root.stm()) :
                                              controls::None {.start_time = m_shared.search_start_time};
 
@@ -171,7 +173,7 @@ namespace rose {
     // If we didn't complete depth 1 we have to scrounge up a move.
 
     // Try the TT first
-    const auto tte = tt_load(m_root, 0);
+    const auto tte = tt_load(m_hash_stack.back(), 0);
     if (m_root.is_legal(tte.move)) {
       pv.write(tte.move);
       return tte.score;
@@ -326,7 +328,7 @@ namespace rose {
     const Color stm = position.stm();
     const Bitboard enemy_threatened = position.attack_table(!stm).bitboard_any();
 
-    const tt::LookupResult tte = tt_load(position, ply);
+    const tt::LookupResult tte = tt_load(m_hash_stack.back(), ply);
     Move hint_move = tte.move;
 
     // Transposition Table Cutoffs
@@ -401,7 +403,7 @@ namespace rose {
       search<NodeType::pv>(ctrl, position, pv, alpha, beta, ss, ply, iid_depth);
       m_in_iid = prev_in_iid;
 
-      const auto iid_tte = tt_load(position, ply);
+      const auto iid_tte = tt_load(m_hash_stack.back(), ply);
       hint_move = iid_tte.move;
       if (m_in_iid && iid_tte.depth >= depth)
         return iid_tte.score;
@@ -621,7 +623,7 @@ namespace rose {
     }
 
     if (!excluded) {
-      tt_store(position,
+      tt_store(m_hash_stack.back(),
                ply,
                tt::LookupResult {
                  .depth = depth,
@@ -666,7 +668,7 @@ namespace rose {
 
     const bool is_in_check = position.is_in_check();
 
-    const tt::LookupResult tte = tt_load(position, ply);
+    const tt::LookupResult tte = tt_load(m_hash_stack.back(), ply);
 
     // Transposition Table Cutoffs
     if (leaf_expected != NodeType::pv && tte.is_some() && [&] {
@@ -758,20 +760,20 @@ namespace rose {
   }
 
   template<eval::concepts::State Evaluation>
-  auto Search<Evaluation>::tt_load(const Position& position, i32 ply) -> tt::LookupResult {
-    return m_shared.transposition_table.load(position.hash(), ply);
+  auto Search<Evaluation>::tt_load(Hash hash, i32 ply) -> tt::LookupResult {
+    return m_shared.transposition_table.load(hash, ply);
   }
 
   template<eval::concepts::State Evaluation>
-  auto Search<Evaluation>::tt_store(const Position& position, i32 ply, tt::LookupResult lr) -> void {
-    m_shared.transposition_table.store(position.hash(), ply, lr);
+  auto Search<Evaluation>::tt_store(Hash hash, i32 ply, tt::LookupResult lr) -> void {
+    m_shared.transposition_table.store(hash, ply, lr);
   }
 
   template<eval::concepts::State Evaluation>
   auto Search<Evaluation>::make_move(SearchStack* ss, const Position& position, Move mv) -> Position {
     m_evaluation.push();
+    m_hash_stack.push_back(position.hash_after(m_hash_stack.back(), mv));
     const Position child_position = position.move(mv, m_evaluation.observer());
-    m_hash_stack.push_back(child_position.hash());
     ss->move = mv;
     ss->conthist = m_sd.continuation_history.get_subtable(!child_position.stm(), child_position.place_at(mv.to()).ptype(), mv);
     ss[1].static_eval = score::none;
@@ -781,8 +783,8 @@ namespace rose {
   template<eval::concepts::State Evaluation>
   auto Search<Evaluation>::make_null_move(SearchStack* ss, const Position& position) -> Position {
     m_evaluation.push();
+    m_hash_stack.push_back(position.hash_after_null_move(m_hash_stack.back()));
     const Position child_position = position.null_move();
-    m_hash_stack.push_back(child_position.hash());
     ss->move = Move::none();
     ss->conthist = nullptr;
     ss[1].static_eval = score::none;

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -173,7 +173,7 @@ namespace rose {
     // If we didn't complete depth 1 we have to scrounge up a move.
 
     // Try the TT first
-    const auto tte = tt_load(m_hash_stack.back(), 0);
+    const auto tte = tt_load();
     if (m_root.is_legal(tte.move)) {
       pv.write(tte.move);
       return tte.score;
@@ -328,7 +328,7 @@ namespace rose {
     const Color stm = position.stm();
     const Bitboard enemy_threatened = position.attack_table(!stm).bitboard_any();
 
-    const tt::LookupResult tte = tt_load(m_hash_stack.back(), ply);
+    const tt::LookupResult tte = tt_load();
     Move hint_move = tte.move;
 
     // Transposition Table Cutoffs
@@ -403,7 +403,7 @@ namespace rose {
       search<NodeType::pv>(ctrl, position, pv, alpha, beta, ss, ply, iid_depth);
       m_in_iid = prev_in_iid;
 
-      const auto iid_tte = tt_load(m_hash_stack.back(), ply);
+      const auto iid_tte = tt_load();
       hint_move = iid_tte.move;
       if (m_in_iid && iid_tte.depth >= depth)
         return iid_tte.score;
@@ -623,14 +623,12 @@ namespace rose {
     }
 
     if (!excluded) {
-      tt_store(m_hash_stack.back(),
-               ply,
-               tt::LookupResult {
-                 .depth = depth,
-                 .bound = actual_node_type,
-                 .score = best_score,
-                 .move = best_move,
-               });
+      tt_store(tt::LookupResult {
+        .depth = depth,
+        .bound = actual_node_type,
+        .score = best_score,
+        .move = best_move,
+      });
     }
 
     return best_score;
@@ -668,7 +666,7 @@ namespace rose {
 
     const bool is_in_check = position.is_in_check();
 
-    const tt::LookupResult tte = tt_load(m_hash_stack.back(), ply);
+    const tt::LookupResult tte = tt_load();
 
     // Transposition Table Cutoffs
     if (leaf_expected != NodeType::pv && tte.is_some() && [&] {
@@ -760,13 +758,17 @@ namespace rose {
   }
 
   template<eval::concepts::State Evaluation>
-  auto Search<Evaluation>::tt_load(Hash hash, i32 ply) -> tt::LookupResult {
-    return m_shared.transposition_table.load(hash, ply);
+  auto Search<Evaluation>::tt_load() -> tt::LookupResult {
+    rose_assert(m_hash_stack.size() > m_hash_waterline);
+    const i32 ply = static_cast<i32>(m_hash_stack.size() - 1 - m_hash_waterline);
+    return m_shared.transposition_table.load(m_hash_stack.back(), ply);
   }
 
   template<eval::concepts::State Evaluation>
-  auto Search<Evaluation>::tt_store(Hash hash, i32 ply, tt::LookupResult lr) -> void {
-    m_shared.transposition_table.store(hash, ply, lr);
+  auto Search<Evaluation>::tt_store(tt::LookupResult lr) -> void {
+    rose_assert(m_hash_stack.size() > m_hash_waterline);
+    const i32 ply = static_cast<i32>(m_hash_stack.size() - 1 - m_hash_waterline);
+    m_shared.transposition_table.store(m_hash_stack.back(), ply, lr);
   }
 
   template<eval::concepts::State Evaluation>

--- a/src/rose/search.hpp
+++ b/src/rose/search.hpp
@@ -175,8 +175,8 @@ namespace rose {
 
     auto eval(const Position& position) -> Score;
 
-    auto tt_load(Hash hash, i32 ply) -> tt::LookupResult;
-    auto tt_store(Hash hash, i32 ply, tt::LookupResult lr) -> void;
+    auto tt_load() -> tt::LookupResult;
+    auto tt_store(tt::LookupResult lr) -> void;
 
     [[nodiscard]] auto make_move(SearchStack* ss, const Position& position, Move mv) -> Position;
     [[nodiscard]] auto make_null_move(SearchStack* ss, const Position& position) -> Position;

--- a/src/rose/search.hpp
+++ b/src/rose/search.hpp
@@ -175,8 +175,8 @@ namespace rose {
 
     auto eval(const Position& position) -> Score;
 
-    auto tt_load(const Position& position, i32 ply) -> tt::LookupResult;
-    auto tt_store(const Position& position, i32 ply, tt::LookupResult lr) -> void;
+    auto tt_load(Hash hash, i32 ply) -> tt::LookupResult;
+    auto tt_store(Hash hash, i32 ply, tt::LookupResult lr) -> void;
 
     [[nodiscard]] auto make_move(SearchStack* ss, const Position& position, Move mv) -> Position;
     [[nodiscard]] auto make_null_move(SearchStack* ss, const Position& position) -> Position;


### PR DESCRIPTION
Remove redundant m_hash member variable from Position.

FN
Elo   | -0.00 +- 0.00 (95%)
SPRT  | N=10000 Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 14072 W: 4541 L: 4541 D: 4990
Penta | [0, 0, 7036, 0, 0]

No functional change.

Bench: 7328768

