### PR TITLE
Fix lmr_depth clamping

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -525,7 +525,7 @@ namespace rose {
         reduction += 1024 * (expected == NodeType::cut);
         reduction -= 768 * child_position.is_in_check();
 
-        const i32 lmr_depth = std::clamp(new_depth - reduction / 1024, 0, new_depth) + (expected == NodeType::pv);
+        const i32 lmr_depth = std::min(std::max(new_depth - reduction / 1024, 0), new_depth) + (expected == NodeType::pv);
 
         score = -search<expected.next()>(ctrl, child_position, child_pv, -alpha - 1, -alpha, ss + 1, ply + 1, lmr_depth);
 


### PR DESCRIPTION
Future patches may have new_depth < 0.

FN nonreg
Elo   | -0.00 +- 0.00 (95%)
SPRT  | N=10000 Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 14138 W: 4781 L: 4781 D: 4576
Penta | [0, 0, 7069, 0, 0]

Bench: 7328768