### PR TITLE
Hindsight extension

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -356,6 +356,11 @@ namespace rose {
                                                                false;
 
     if (expected != NodeType::pv && !is_in_check && !excluded) {
+      // Hindsight extension
+      if (depth <= 20 && ss[-1].reduction >= 4 && ss[-1].static_eval != score::none && static_eval <= -ss[-1].static_eval) {
+        depth++;
+      }
+
       // Reverse Futility Pruning
       if (depth <= 15 && static_eval - 64 * depth - 4 * depth * depth >= beta) {
         return static_eval;
@@ -527,7 +532,9 @@ namespace rose {
 
         const i32 lmr_depth = std::min(std::max(new_depth - reduction / 1024, 0), new_depth) + (expected == NodeType::pv);
 
+        ss->reduction = new_depth - lmr_depth;
         score = -search<expected.next()>(ctrl, child_position, child_pv, -alpha - 1, -alpha, ss + 1, ply + 1, lmr_depth);
+        ss->reduction = 0;
 
         if (score > alpha && lmr_depth < new_depth) {
           i32 research_depth = new_depth;

--- a/src/rose/search.hpp
+++ b/src/rose/search.hpp
@@ -93,6 +93,7 @@ namespace rose {
     Move move = Move::none();
     Move excluded = Move::none();
     Score static_eval = score::none;
+    i32 reduction = 0;
     ContinuationHistorySubtable* conthist = nullptr;
   };
 


### PR DESCRIPTION
STC
Elo   | 0.78 +- 1.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.32 (-2.25, 2.89) [0.00, 5.00]
Games | N: 48334 W: 11786 L: 11677 D: 24871
Penta | [596, 5834, 11168, 6003, 566]

LTC
Elo   | 5.47 +- 3.79 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8896 W: 2094 L: 1954 D: 4848
Penta | [41, 978, 2282, 1094, 53]

Bench: 6564632