### PR TITLE
Transposition Table Buckets and Aging

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -294,8 +294,6 @@ namespace rose {
   auto
     Search<Evaluation>::search(const Controls& ctrl, const Position& position, Line& pv, Score alpha, Score beta, SearchStack* ss, i32 ply, i32 depth)
       -> Score {
-    const i32 original_depth = depth;
-
     if (depth <= 0)
       return qsearch<expected>(ctrl, position, pv, alpha, beta, ss, ply);
 
@@ -633,7 +631,7 @@ namespace rose {
 
     if (!excluded) {
       tt_store(tt::LookupResult {
-        .depth = original_depth,
+        .depth = depth,
         .bound = actual_node_type,
         .score = best_score,
         .move = best_move,

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -294,6 +294,8 @@ namespace rose {
   auto
     Search<Evaluation>::search(const Controls& ctrl, const Position& position, Line& pv, Score alpha, Score beta, SearchStack* ss, i32 ply, i32 depth)
       -> Score {
+    const i32 original_depth = depth;
+
     if (depth <= 0)
       return qsearch<expected>(ctrl, position, pv, alpha, beta, ss, ply);
 
@@ -631,7 +633,7 @@ namespace rose {
 
     if (!excluded) {
       tt_store(tt::LookupResult {
-        .depth = depth,
+        .depth = original_depth,
         .bound = actual_node_type,
         .score = best_score,
         .move = best_move,

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -156,6 +156,9 @@ namespace rose {
         m_shared.stopping = false;
         stats().reset();
 
+        if (is_main_thread())
+          m_shared.transposition_table.increment_age();
+
         (void)m_shared.started_barrier.arrive();
 
         std::visit(

--- a/src/rose/tt.cpp
+++ b/src/rose/tt.cpp
@@ -72,6 +72,7 @@ namespace rose::tt {
       Entry& entry = bucket.entries[j];
       if (entry.bound() == NodeType::none) {
         entry = Entry {ply, lr};
+        bucket.set_fragment(j, fragment);
         return;
       }
     }
@@ -80,6 +81,7 @@ namespace rose::tt {
       const usize j = hash % bucket.entries.size();
       Entry& entry = bucket.entries[j];
       entry = Entry {ply, lr};
+      bucket.set_fragment(j, fragment);
     }
   }
 

--- a/src/rose/tt.cpp
+++ b/src/rose/tt.cpp
@@ -71,7 +71,7 @@ namespace rose::tt {
     Entry best_entry = bucket.entries[0];
     usize best_index = 0;
 
-    const auto replacement_score = [this](const Entry& e) {
+    const auto retention_score = [this](const Entry& e) {
       constexpr int max_age = Entry::age_mask + 1;
       return e.depth() - (max_age + m_age - e.age()) * 4;
     };
@@ -83,7 +83,7 @@ namespace rose::tt {
           best_index = j;
           break;
         }
-        if (replacement_score(entry) < replacement_score(best_entry)) {
+        if (retention_score(entry) < retention_score(best_entry)) {
           best_entry = entry;
           best_index = j;
         }

--- a/src/rose/tt.cpp
+++ b/src/rose/tt.cpp
@@ -64,25 +64,37 @@ namespace rose::tt {
       if (lr.move.is_none())
         lr.move = entry.move();
 
-      entry = Entry {ply, lr};
+      entry = Entry {ply, lr, m_age};
       return;
     }
 
-    for (usize j = 0; j < bucket.entries.size(); j++) {
-      Entry& entry = bucket.entries[j];
-      if (entry.bound() == NodeType::none) {
-        entry = Entry {ply, lr};
-        bucket.set_fragment(j, fragment);
-        return;
+    Entry best_entry = bucket.entries[0];
+    usize best_index = 0;
+
+    const auto replacement_score = [this](const Entry& e) {
+      constexpr int max_age = Entry::age_mask + 1;
+      return e.depth() - (max_age + m_age - e.age()) * 4;
+    };
+
+    if (best_entry.bound() != NodeType::none) {
+      for (usize j = 1; j < bucket.entries.size(); j++) {
+        Entry& entry = bucket.entries[j];
+        if (entry.bound() == NodeType::none) {
+          best_index = j;
+          break;
+        }
+        if (replacement_score(entry) < replacement_score(best_entry)) {
+          best_entry = entry;
+          best_index = j;
+        }
       }
     }
 
-    {
-      const usize j = hash % bucket.entries.size();
-      Entry& entry = bucket.entries[j];
-      entry = Entry {ply, lr};
-      bucket.set_fragment(j, fragment);
-    }
+    if (lr.move.is_none())
+      lr.move = best_entry.move();
+
+    bucket.entries[best_index] = Entry {ply, lr, m_age};
+    bucket.set_fragment(best_index, fragment);
   }
 
   auto TT::print(u64 hash) const -> void {
@@ -96,6 +108,7 @@ namespace rose::tt {
     if (const usize j = bucket.lookup_fragment(fragment); j < bucket.entries.size()) {
       const Entry& entry = bucket.entries[j];
       fmt::print("entry raw:   {:016x}\n", entry.raw);
+      fmt::print("entry age:   {}\n", entry.age());
       fmt::print("entry depth: {}\n", entry.depth());
       fmt::print("entry score: {}\n", entry.score(0));
       fmt::print("entry bound: {}\n", entry.bound());

--- a/src/rose/tt.cpp
+++ b/src/rose/tt.cpp
@@ -90,9 +90,6 @@ namespace rose::tt {
       }
     }
 
-    if (lr.move.is_none())
-      lr.move = best_entry.move();
-
     bucket.entries[best_index] = Entry {ply, lr, m_age};
     bucket.set_fragment(best_index, fragment);
   }

--- a/src/rose/tt.cpp
+++ b/src/rose/tt.cpp
@@ -1,6 +1,7 @@
 #include "rose/tt.hpp"
 
 #include "rose/common.hpp"
+#include "rose/node_type.hpp"
 
 #include <cstdlib>
 #include <cstring>
@@ -12,54 +13,74 @@ namespace rose::tt {
   static constexpr inline auto split_hash(usize count, u64 hash) -> std::tuple<usize, u64> {
     const u128 mul = static_cast<u128>(hash) * count;
     const usize index = static_cast<usize>(mul >> 64);
-    const u64 fragment = (static_cast<u64>(mul) >> (64 - Entry::fragment_width)) & Entry::fragment_mask;
+    const u64 fragment = (static_cast<u64>(mul) >> (64 - Bucket::fragment_width)) & Bucket::fragment_mask;
     return {index, fragment};
   }
 
 #ifdef _WIN32
 
-  auto TT::table_alloc(std::size_t m_count) -> Entry* {
-    return static_cast<Entry*>(_aligned_malloc(m_count * sizeof(Entry), 4096));
+  auto TT::table_alloc(std::size_t m_count) -> Bucket* {
+    return static_cast<Bucket*>(_aligned_malloc(m_count * sizeof(Bucket), 4096));
   }
 
-  auto TT::table_free(Entry* ptr) -> void {
+  auto TT::table_free(Bucket* ptr) -> void {
     return _aligned_free(ptr);
   }
 
 #else
 
-  auto TT::table_alloc(std::size_t m_count) -> Entry* {
-    return static_cast<Entry*>(std::aligned_alloc(4096, m_count * sizeof(Entry)));
+  auto TT::table_alloc(std::size_t m_count) -> Bucket* {
+    return static_cast<Bucket*>(std::aligned_alloc(4096, m_count * sizeof(Bucket)));
   }
 
-  auto TT::table_free(Entry* ptr) -> void {
+  auto TT::table_free(Bucket* ptr) -> void {
     return std::free(ptr);
   }
 
 #endif
 
   auto TT::clear() -> void {
-    std::memset(m_table.get(), 0, m_count * sizeof(Entry));
+    std::memset(m_table.get(), 0, m_count * sizeof(Bucket));
   }
 
   auto TT::load(u64 hash, int ply) const -> LookupResult {
     const auto [index, fragment] = split_hash(m_count, hash);
-    const Entry& entry = m_table.get()[index];
+    const Bucket& bucket = m_table.get()[index];
 
-    if (entry.fragment() == fragment) {
-      return entry.toResult(ply);
+    if (const usize j = bucket.lookup_fragment(fragment); j < bucket.entries.size()) {
+      const Entry& entry = bucket.entries[j];
+      return entry.to_result(ply);
     }
     return {};
   }
 
   auto TT::store(u64 hash, int ply, LookupResult lr) -> void {
     const auto [index, fragment] = split_hash(m_count, hash);
-    Entry& entry = m_table.get()[index];
+    Bucket& bucket = m_table.get()[index];
 
-    if (entry.fragment() == fragment && lr.move.is_none())
-      lr.move = entry.move();
+    if (const usize j = bucket.lookup_fragment(fragment); j < bucket.entries.size()) {
+      Entry& entry = bucket.entries[j];
 
-    entry = Entry {fragment, ply, lr};
+      if (lr.move.is_none())
+        lr.move = entry.move();
+
+      entry = Entry {ply, lr};
+      return;
+    }
+
+    for (usize j = 0; j < bucket.entries.size(); j++) {
+      Entry& entry = bucket.entries[j];
+      if (entry.bound() == NodeType::none) {
+        entry = Entry {ply, lr};
+        return;
+      }
+    }
+
+    {
+      const usize j = hash % bucket.entries.size();
+      Entry& entry = bucket.entries[j];
+      entry = Entry {ply, lr};
+    }
   }
 
   auto TT::print(u64 hash) const -> void {
@@ -68,13 +89,18 @@ namespace rose::tt {
     fmt::print("frag:   {:06x}\n", fragment);
     fmt::print("index:  0x{:x}/0x{:x}\n", index, m_count);
 
-    const Entry& entry = m_table.get()[index];
-    fmt::print("entry raw:   {:016x}\n", entry.raw);
-    fmt::print("entry frag:  {:06x}{}\n", entry.fragment(), entry.fragment() != fragment ? " [mismatch!]" : "");
-    fmt::print("entry depth: {}\n", entry.depth());
-    fmt::print("entry score: {}\n", entry.score(0));
-    fmt::print("entry bound: {}\n", entry.bound());
-    fmt::print("entry move:  {}\n", entry.move().to_string(MoveFormat::frc));
+    const Bucket& bucket = m_table.get()[index];
+
+    if (const usize j = bucket.lookup_fragment(fragment); j < bucket.entries.size()) {
+      const Entry& entry = bucket.entries[j];
+      fmt::print("entry raw:   {:016x}\n", entry.raw);
+      fmt::print("entry depth: {}\n", entry.depth());
+      fmt::print("entry score: {}\n", entry.score(0));
+      fmt::print("entry bound: {}\n", entry.bound());
+      fmt::print("entry move:  {}\n", entry.move().to_string(MoveFormat::frc));
+    } else {
+      fmt::print("not found in bucket\n");
+    }
   }
 
 }  // namespace rose::tt

--- a/src/rose/tt.cpp
+++ b/src/rose/tt.cpp
@@ -73,7 +73,7 @@ namespace rose::tt {
 
     const auto retention_score = [this](const Entry& e) {
       constexpr int max_age = Entry::age_mask + 1;
-      return e.depth() - (max_age + m_age - e.age()) * 4;
+      return e.depth() - (max_age + m_age - e.age()) % max_age * 4;
     };
 
     if (best_entry.bound() != NodeType::none) {

--- a/src/rose/tt.hpp
+++ b/src/rose/tt.hpp
@@ -34,24 +34,34 @@ namespace rose::tt {
     // u16 move
     // u8 depth
     // u2 bounds
-    // u22 unused
+    // u5 age
+    // u17 unused
+    static inline constexpr usize age_shift = 17;
     static inline constexpr usize bounds_shift = 22;
     static inline constexpr usize depth_shift = 24;
     static inline constexpr usize move_shift = 32;
     static inline constexpr usize score_shift = 48;
 
+    static inline constexpr usize age_width = 5;
+    static inline constexpr int age_mask = (1 << age_width) - 1;
+
     u64 raw = 0;
 
-    constexpr Entry(i32 ply, LookupResult lr) {
+    constexpr Entry(i32 ply, LookupResult lr, int age) {
       const i32 tt_score = score::adjust_plys_to_mate(lr.score, -ply);
       const i32 tt_depth = std::clamp(lr.depth, 0, 255);
       const u64 tt_bound = std::to_underlying(lr.bound.raw);
 
       raw = 0;
+      raw |= static_cast<u64>(age & age_mask) << age_shift;
       raw |= static_cast<u64>(tt_bound) << bounds_shift;
       raw |= static_cast<u64>(tt_depth) << depth_shift;
       raw |= static_cast<u64>(lr.move.raw) << move_shift;
       raw |= static_cast<u64>(tt_score) << score_shift;
+    }
+
+    constexpr inline auto age() const -> int {
+      return static_cast<int>((raw >> age_shift) & 0x1F);
     }
 
     constexpr inline auto bound() const -> NodeType {
@@ -123,6 +133,7 @@ namespace rose::tt {
     static auto table_alloc(std::size_t m_count) -> Bucket*;
     static auto table_free(Bucket* ptr) -> void;
 
+    int m_age = 0;
     usize m_count;
     std::unique_ptr<Bucket, decltype(&table_free)> m_table;
 
@@ -140,6 +151,10 @@ namespace rose::tt {
     }
 
     auto clear() -> void;
+
+    auto increment_age() -> void {
+      m_age = (m_age + 1) & Entry::age_mask;
+    }
 
     auto load(u64 hash, int ply) const -> LookupResult;
     auto store(u64 hash, int ply, LookupResult lr) -> void;

--- a/src/rose/tt.hpp
+++ b/src/rose/tt.hpp
@@ -5,6 +5,7 @@
 #include "rose/node_type.hpp"
 #include "rose/score.hpp"
 
+#include <bit>
 #include <memory>
 
 namespace rose::tt {
@@ -33,33 +34,24 @@ namespace rose::tt {
     // u16 move
     // u8 depth
     // u2 bounds
-    // u22 fragment
-    static inline constexpr usize fragment_width = 22;
+    // u22 unused
     static inline constexpr usize bounds_shift = 22;
     static inline constexpr usize depth_shift = 24;
     static inline constexpr usize move_shift = 32;
     static inline constexpr usize score_shift = 48;
-    static inline constexpr u64 fragment_mask = (static_cast<u64>(1) << fragment_width) - 1;
 
     u64 raw = 0;
 
-    constexpr Entry(u64 fragment, i32 ply, LookupResult lr) {
+    constexpr Entry(i32 ply, LookupResult lr) {
       const i32 tt_score = score::adjust_plys_to_mate(lr.score, -ply);
       const i32 tt_depth = std::clamp(lr.depth, 0, 255);
       const u64 tt_bound = std::to_underlying(lr.bound.raw);
 
-      rose_assert((fragment & fragment_mask) == fragment);
-
       raw = 0;
-      raw |= fragment;
       raw |= static_cast<u64>(tt_bound) << bounds_shift;
       raw |= static_cast<u64>(tt_depth) << depth_shift;
       raw |= static_cast<u64>(lr.move.raw) << move_shift;
       raw |= static_cast<u64>(tt_score) << score_shift;
-    }
-
-    constexpr inline auto fragment() const -> u64 {
-      return raw & fragment_mask;
     }
 
     constexpr inline auto bound() const -> NodeType {
@@ -79,7 +71,7 @@ namespace rose::tt {
       return score::adjust_plys_to_mate(tt_score, +ply);
     }
 
-    constexpr auto toResult(i32 ply) const -> LookupResult {
+    constexpr auto to_result(i32 ply) const -> LookupResult {
       return {
         .depth = depth(),
         .bound = bound(),
@@ -91,17 +83,48 @@ namespace rose::tt {
 
   static_assert(sizeof(Entry) == sizeof(u64));
 
+  struct Bucket {
+    static inline constexpr usize entry_count = 3;
+    static inline constexpr usize fragment_width = 21;
+    static inline constexpr u64 fragment_mask = (u64 {1} << fragment_width) - 1;
+    static_assert(entry_count * fragment_width < 64);
+
+    std::array<Entry, entry_count> entries;
+    u64 fragments;
+
+    auto fragment(usize index) const -> u64 {
+      const usize shift = index * fragment_width;
+      return (fragments >> shift) & fragment_mask;
+    }
+
+    auto set_fragment(usize index, u64 fragment) -> void {
+      const usize shift = index * fragment_width;
+      fragments &= ~(fragment_mask << shift);
+      fragments |= fragment << shift;
+    }
+
+    auto lookup_fragment(u64 fragment) const -> usize {
+      constexpr u64 bits = u64 {1} | (u64 {1} << fragment_width) | (u64 {1} << (fragment_width * 2));
+      const u64 needle = bits * fragment;
+      const u64 zeros = fragments ^ needle;
+      const u64 matches = (zeros - bits) & ~zeros & (bits << (fragment_width - 1));
+      return static_cast<usize>(std::countr_zero(matches) / fragment_width);
+    }
+  };
+
+  static_assert(sizeof(Bucket) == sizeof(u64) * 4);
+
   constexpr inline auto mb_to_count(usize mb) -> usize {
-    return mb * 1024 * 1024 / sizeof(Entry);
+    return mb * 1024 * 1024 / sizeof(Bucket);
   }
 
   struct TT {
   private:
-    static auto table_alloc(std::size_t m_count) -> Entry*;
-    static auto table_free(Entry* ptr) -> void;
+    static auto table_alloc(std::size_t m_count) -> Bucket*;
+    static auto table_free(Bucket* ptr) -> void;
 
     usize m_count;
-    std::unique_ptr<Entry, decltype(&table_free)> m_table;
+    std::unique_ptr<Bucket, decltype(&table_free)> m_table;
 
   public:
     explicit TT(usize mb) :

--- a/src/rose/tt.hpp
+++ b/src/rose/tt.hpp
@@ -104,7 +104,7 @@ namespace rose::tt {
     }
 
     auto lookup_fragment(u64 fragment) const -> usize {
-      constexpr u64 bits = u64 {1} | (u64 {1} << fragment_width) | (u64 {1} << (fragment_width * 2));
+      constexpr u64 bits = u64 {1} | (u64 {1} << fragment_width) | (u64 {1} << (fragment_width * 2)) | (u64 {1} << (fragment_width * 3));
       const u64 needle = bits * fragment;
       const u64 zeros = fragments ^ needle;
       const u64 matches = (zeros - bits) & ~zeros & (bits << (fragment_width - 1));


### PR DESCRIPTION
Implement TT buckets:
* Three entries per bucket
* 21 bit keys
* 5 bits allocated in entries for age
* Remaining 17 bits of entry space is currently unused

STC (passes non-reg bounds)
Elo   | 0.60 +- 2.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -1.14 (-2.25, 2.89) [0.00, 5.00]
Games | N: 18568 W: 4525 L: 4493 D: 9550
Penta | [229, 2255, 4285, 2285, 230]

STC with hash pressure
Elo   | 19.18 +- 8.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=1MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2376 W: 646 L: 515 D: 1215
Penta | [26, 238, 542, 343, 39]

LTC non-reg
Elo   | 0.67 +- 2.63 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 18680 W: 4191 L: 4155 D: 10334
Penta | [102, 2166, 4778, 2182, 112]

LTC with hash pressure
Elo   | 16.47 +- 7.25 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2428 W: 583 L: 468 D: 1377
Penta | [8, 240, 610, 341, 15]

STC SMP
Elo   | 4.36 +- 3.29 (95%)
SPRT  | 8.0+0.08s Threads=4 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 12742 W: 2992 L: 2832 D: 6918
Penta | [88, 1460, 3114, 1622, 87]

Bench: 7222666