### PR TITLE
Quiescence Search Transposition Table Store

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -759,6 +759,13 @@ namespace rose {
         moves.skip_quiet();
     }
 
+    tt_store(tt::LookupResult {
+      .depth = 0,
+      .bound = actual_node_type,
+      .score = best_score,
+      .move = best_move,
+    });
+
     return best_score;
   }
 


### PR DESCRIPTION
STC
Elo   | 7.05 +- 4.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7396 W: 1891 L: 1741 D: 3764
Penta | [62, 907, 1665, 947, 117]

LTC
Elo   | 2.77 +- 2.25 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 25104 W: 5607 L: 5407 D: 14090
Penta | [109, 2862, 6449, 2984, 148]

Bench: 7978458