### PR TITLE
Store evaluation in Transposition Table

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -350,7 +350,15 @@ namespace rose {
       return tte.score;
     }
 
-    const i32 static_eval = ss->static_eval != score::none ? ss->static_eval : is_in_check ? score::none : eval(position);
+    const i32 static_eval = [&, this] {
+      if (is_in_check)
+        return score::none;
+      if (ss->static_eval != score::none)
+        return ss->static_eval;
+      if (tte.eval != score::none)
+        return tte.eval;
+      return eval(position);
+    }();
     ss->static_eval = static_eval;
 
     const bool improving = is_in_check                       ? false :
@@ -637,6 +645,7 @@ namespace rose {
         .depth = depth,
         .bound = actual_node_type,
         .score = best_score,
+        .eval = static_eval,
         .move = best_move,
       });
     }
@@ -694,7 +703,15 @@ namespace rose {
       return tte.score;
     }
 
-    const Score static_eval = ss->static_eval != score::none ? ss->static_eval : is_in_check ? score::none : eval(position);
+    const i32 static_eval = [&, this] {
+      if (is_in_check)
+        return score::none;
+      if (ss->static_eval != score::none)
+        return ss->static_eval;
+      if (tte.eval != score::none)
+        return tte.eval;
+      return eval(position);
+    }();
     ss->static_eval = static_eval;
 
     Score best_score = is_in_check ? score::mated(ply) : static_eval;

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -357,7 +357,17 @@ namespace rose {
         return ss->static_eval;
       if (tte.eval != score::none)
         return tte.eval;
-      return eval(position);
+
+      const Score static_eval = eval(position);
+      if (tte.is_none())
+        tt_store(tt::LookupResult {
+          .depth = 0,
+          .bound = NodeType::none,
+          .score = score::none,
+          .eval = static_eval,
+          .move = Move::none(),
+        });
+      return static_eval;
     }();
     ss->static_eval = static_eval;
 
@@ -710,7 +720,17 @@ namespace rose {
         return ss->static_eval;
       if (tte.eval != score::none)
         return tte.eval;
-      return eval(position);
+
+      const Score static_eval = eval(position);
+      if (tte.is_none())
+        tt_store(tt::LookupResult {
+          .depth = 0,
+          .bound = NodeType::none,
+          .score = score::none,
+          .eval = static_eval,
+          .move = Move::none(),
+        });
+      return static_eval;
     }();
     ss->static_eval = static_eval;
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -350,7 +350,7 @@ namespace rose {
       return tte.score;
     }
 
-    const i32 static_eval = [&, this] {
+    const Score static_eval = [&, this] {
       if (is_in_check)
         return score::none;
       if (ss->static_eval != score::none)
@@ -703,7 +703,7 @@ namespace rose {
       return tte.score;
     }
 
-    const i32 static_eval = [&, this] {
+    const Score static_eval = [&, this] {
       if (is_in_check)
         return score::none;
       if (ss->static_eval != score::none)

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -780,6 +780,7 @@ namespace rose {
       .depth = 0,
       .bound = actual_node_type,
       .score = best_score,
+      .eval = static_eval,
       .move = best_move,
     });
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -357,17 +357,7 @@ namespace rose {
         return ss->static_eval;
       if (tte.eval != score::none)
         return tte.eval;
-
-      const Score static_eval = eval(position);
-      if (tte.is_none())
-        tt_store(tt::LookupResult {
-          .depth = 0,
-          .bound = NodeType::none,
-          .score = score::none,
-          .eval = static_eval,
-          .move = Move::none(),
-        });
-      return static_eval;
+      return eval(position);
     }();
     ss->static_eval = static_eval;
 
@@ -720,17 +710,7 @@ namespace rose {
         return ss->static_eval;
       if (tte.eval != score::none)
         return tte.eval;
-
-      const Score static_eval = eval(position);
-      if (tte.is_none())
-        tt_store(tt::LookupResult {
-          .depth = 0,
-          .bound = NodeType::none,
-          .score = score::none,
-          .eval = static_eval,
-          .move = Move::none(),
-        });
-      return static_eval;
+      return eval(position);
     }();
     ss->static_eval = static_eval;
 

--- a/src/rose/tt.hpp
+++ b/src/rose/tt.hpp
@@ -67,7 +67,7 @@ namespace rose::tt {
 
     constexpr inline auto eval() const -> Score {
       const usize sext_shift = 64 - 16;
-      return static_cast<Score>(static_cast<i64>(raw >> score_shift << sext_shift) >> sext_shift);
+      return static_cast<Score>(static_cast<i64>(raw >> eval_shift << sext_shift) >> sext_shift);
     }
 
     constexpr inline auto age() const -> int {

--- a/src/rose/tt.hpp
+++ b/src/rose/tt.hpp
@@ -16,7 +16,8 @@ namespace rose::tt {
   struct LookupResult {
     i32 depth = 0;
     NodeType bound = NodeType::none;
-    i32 score = 0;
+    Score score = score::none;
+    Score eval = score::none;
     Move move = Move::none();
 
     auto is_none() const -> bool {
@@ -35,7 +36,9 @@ namespace rose::tt {
     // u8 depth
     // u2 bounds
     // u5 age
-    // u17 unused
+    // u1 unused
+    // i16 eval
+    static inline constexpr usize eval_shift = 0;
     static inline constexpr usize age_shift = 17;
     static inline constexpr usize bounds_shift = 22;
     static inline constexpr usize depth_shift = 24;
@@ -51,8 +54,10 @@ namespace rose::tt {
       const i32 tt_score = score::adjust_plys_to_mate(lr.score, -ply);
       const i32 tt_depth = std::clamp(lr.depth, 0, 255);
       const u64 tt_bound = std::to_underlying(lr.bound.raw);
+      const u64 tt_eval = static_cast<u64>(lr.eval) & 0xFFFF;
 
       raw = 0;
+      raw |= static_cast<u64>(tt_eval) << eval_shift;
       raw |= static_cast<u64>(age & age_mask) << age_shift;
       raw |= static_cast<u64>(tt_bound) << bounds_shift;
       raw |= static_cast<u64>(tt_depth) << depth_shift;
@@ -60,8 +65,13 @@ namespace rose::tt {
       raw |= static_cast<u64>(tt_score) << score_shift;
     }
 
+    constexpr inline auto eval() const -> Score {
+      const usize sext_shift = 64 - 16;
+      return static_cast<Score>(static_cast<i64>(raw >> score_shift << sext_shift) >> sext_shift);
+    }
+
     constexpr inline auto age() const -> int {
-      return static_cast<int>((raw >> age_shift) & 0x1F);
+      return static_cast<int>((raw >> age_shift) & age_mask);
     }
 
     constexpr inline auto bound() const -> NodeType {
@@ -76,8 +86,8 @@ namespace rose::tt {
       return Move {static_cast<u16>(raw >> move_shift)};
     }
 
-    constexpr inline auto score(i32 ply) const -> i32 {
-      const i32 tt_score = static_cast<i32>(static_cast<i64>(raw) >> score_shift);
+    constexpr inline auto score(i32 ply) const -> Score {
+      const Score tt_score = static_cast<Score>(static_cast<i64>(raw) >> score_shift);
       return score::adjust_plys_to_mate(tt_score, +ply);
     }
 
@@ -86,6 +96,7 @@ namespace rose::tt {
         .depth = depth(),
         .bound = bound(),
         .score = score(ply),
+        .eval = eval(),
         .move = move(),
       };
     }


### PR DESCRIPTION
STC
Elo   | 5.35 +- 3.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10336 W: 2607 L: 2448 D: 5281
Penta | [101, 1135, 2561, 1246, 125]

LTC (non-reg)
Elo   | 0.15 +- 2.20 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 24984 W: 5591 L: 5580 D: 13813
Penta | [122, 2772, 6693, 2783, 122]

STC SMP (non-reg)
Elo   | 5.76 +- 5.01 (95%)
SPRT  | 8.0+0.08s Threads=4 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 5246 W: 1230 L: 1143 D: 2873
Penta | [30, 574, 1335, 647, 37]

Bench: 7978458