### PR TITLE
TT: Tweak replacement policy on same key

### DIFF
--- a/src/rose/tt.cpp
+++ b/src/rose/tt.cpp
@@ -55,6 +55,11 @@ namespace rose::tt {
   }
 
   auto TT::store(u64 hash, int ply, LookupResult lr) -> void {
+    const auto retention_score = [this](const Entry& e) {
+      constexpr int max_age = Entry::age_mask + 1;
+      return e.depth() - (max_age + m_age - e.age()) % max_age * 4;
+    };
+
     const auto [index, fragment] = split_hash(m_count, hash);
     Bucket& bucket = m_table.get()[index];
 
@@ -64,17 +69,14 @@ namespace rose::tt {
       if (lr.move.is_none())
         lr.move = entry.move();
 
-      entry = Entry {ply, lr, m_age};
+      if ((entry.bound() != NodeType::pv && lr.bound == NodeType::pv && lr.depth > 0) || (lr.depth * 3 >= retention_score(entry) * 2))
+        entry = Entry {ply, lr, m_age};
+
       return;
     }
 
     Entry best_entry = bucket.entries[0];
     usize best_index = 0;
-
-    const auto retention_score = [this](const Entry& e) {
-      constexpr int max_age = Entry::age_mask + 1;
-      return e.depth() - (max_age + m_age - e.age()) % max_age * 4;
-    };
 
     if (best_entry.bound() != NodeType::none) {
       for (usize j = 1; j < bucket.entries.size(); j++) {

--- a/src/rose/tt.cpp
+++ b/src/rose/tt.cpp
@@ -69,7 +69,7 @@ namespace rose::tt {
       if (lr.move.is_none())
         lr.move = entry.move();
 
-      if ((entry.bound() != NodeType::pv && lr.bound == NodeType::pv && lr.depth > 0) || (lr.depth * 3 >= retention_score(entry) * 2))
+      if ((entry.bound() != NodeType::pv && lr.bound == NodeType::pv && lr.depth > 0) || (lr.depth >= retention_score(entry)))
         entry = Entry {ply, lr, m_age};
 
       return;

--- a/src/rose/tt.cpp
+++ b/src/rose/tt.cpp
@@ -69,7 +69,7 @@ namespace rose::tt {
       if (lr.move.is_none())
         lr.move = entry.move();
 
-      if ((entry.bound() != NodeType::pv && lr.bound == NodeType::pv && lr.depth > 0) || (lr.depth >= retention_score(entry)))
+      if ((entry.bound() != NodeType::pv && lr.bound == NodeType::pv && lr.depth > 0) || (lr.depth * 2 >= retention_score(entry)))
         entry = Entry {ply, lr, m_age};
 
       return;


### PR DESCRIPTION
STC (hash pressure)
Elo   | 6.15 +- 4.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=1MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8696 W: 2219 L: 2065 D: 4412
Penta | [86, 1022, 2011, 1110, 119]

LTC (hash pressure)
Elo   | 4.25 +- 3.20 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 12744 W: 2832 L: 2676 D: 7236
Penta | [66, 1435, 3233, 1553, 85]

Bench: 6650691