### PR TITLE
Refactor stability TM code

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -258,14 +258,12 @@ namespace rose {
 
       if (last_pv.first_move() != pv.first_move())
         pv_last_unstable = depth;
-      if (std::abs(average_score - score) >= 28_z)
+      if (std::abs(last_score - score) >= 28_z)
         score_last_unstable = depth;
 
       last_score = score;
       last_pv = pv;
       last_depth = depth;
-
-      average_score = average_score == score::none ? score : (average_score + score) / 2;
 
       if (is_main_thread()) {
         const i32 pv_stability = depth - pv_last_unstable;

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -256,8 +256,6 @@ namespace rose {
       if (m_shared.stopping)
         break;
 
-      average_score = average_score == score::none ? score : (average_score + score) / 2;
-
       if (last_pv.first_move() != pv.first_move())
         pv_last_unstable = depth;
       if (std::abs(average_score - score) >= 28_z)
@@ -266,6 +264,8 @@ namespace rose {
       last_score = score;
       last_pv = pv;
       last_depth = depth;
+
+      average_score = average_score == score::none ? score : (average_score + score) / 2;
 
       if (is_main_thread()) {
         const i32 pv_stability = depth - pv_last_unstable;

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -208,8 +208,8 @@ namespace rose {
 
     m_evaluation.reset(m_root);
 
-    i32 pv_stability = 0;
-    i32 score_stability = 0;
+    i32 pv_last_unstable = 0;
+    i32 score_last_unstable = 0;
 
     for (i32 depth = 1; depth < max_depth; depth++) {
       Line pv {};
@@ -217,6 +217,7 @@ namespace rose {
       Score beta = score::infinity;
       Score delta = 17_z;
       Score score = score::none;
+      Score average_score = score::none;
 
       if (depth >= 4) {
         alpha = last_score - delta;
@@ -255,23 +256,21 @@ namespace rose {
       if (m_shared.stopping)
         break;
 
-      if (last_pv.first_move() == pv.first_move()) {
-        pv_stability++;
-      } else {
-        pv_stability = 0;
-      }
+      average_score = average_score == score::none ? score : (average_score + score) / 2;
 
-      if (std::abs(last_score - score) < 28_z) {
-        score_stability++;
-      } else {
-        score_stability = 0;
-      }
+      if (last_pv.first_move() != pv.first_move())
+        pv_last_unstable = depth;
+      if (std::abs(average_score - score) >= 28_z)
+        score_last_unstable = depth;
 
       last_score = score;
       last_pv = pv;
       last_depth = depth;
 
       if (is_main_thread()) {
+        const i32 pv_stability = depth - pv_last_unstable;
+        const i32 score_stability = depth - score_last_unstable;
+
         const f32 time_multiplier = std::clamp(1.0 - pv_stability * 0.05116902193882232_z, 0.592028611604442_z, 1.0855072225856215_z) *
                                     std::clamp(1.0 - score_stability * 0.04828987665300888_z, 0.667434450591335_z, 1.1385035397539525_z);
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -217,7 +217,6 @@ namespace rose {
       Score beta = score::infinity;
       Score delta = 17_z;
       Score score = score::none;
-      Score average_score = score::none;
 
       if (depth >= 4) {
         alpha = last_score - delta;


### PR DESCRIPTION
STC (nonreg)
Elo   | -0.45 +- 1.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 42596 W: 10282 L: 10337 D: 21977
Penta | [370, 4494, 11634, 4421, 379]

No functional change.

Bench: 6650691