### PR TITLE
draw: Upperbound is_repetition detection with fifty move clock

### DIFF
--- a/src/rose/game.hpp
+++ b/src/rose/game.hpp
@@ -45,7 +45,7 @@ namespace rose {
 
     auto is_draw_slow() const -> bool {
       const Position& pos = position();
-      return draw::is_stalemate(pos) || draw::is_fifty_move_draw(pos, 0) == 0 || draw::is_repetition(hash_stack(), hash_stack().size());
+      return draw::is_stalemate(pos) || draw::is_fifty_move_draw(pos, 0) == 0 || draw::is_repetition(pos, hash_stack(), hash_stack().size());
     }
 
     auto set_position(const Position& new_pos) -> void {

--- a/src/rose/is_draw.hpp
+++ b/src/rose/is_draw.hpp
@@ -22,14 +22,19 @@ namespace rose::draw {
     return 0;
   }
 
-  inline auto is_repetition(const std::vector<Hash>& hash_stack, usize hash_waterline) -> bool {
+  inline auto is_repetition(const Position& pos, const std::vector<Hash>& hash_stack, usize hash_waterline) -> bool {
     const int height = static_cast<int>(hash_stack.size()) - 1;
-    const Hash current_hash = hash_stack[height];
+    const int end = std::min<int>(pos.fifty_move_clock(), height);
+
+    const auto hash_at = [&hash_stack, height](int i) {
+      return hash_stack[height - i];
+    };
+    const Hash current_hash = hash_at(0);
 
     usize clones = 0;
-    for (int i = height - 4; i >= 0; i -= 2) {
-      if (hash_stack[i] == current_hash) {
-        const usize clone_limit = i < hash_waterline ? 2 : 1;
+    for (int i = 4; i <= end; i += 2) {
+      if (hash_at(i) == current_hash) {
+        const usize clone_limit = (height - i) < hash_waterline ? 2 : 1;
         clones++;
         if (clones >= clone_limit)
           return true;

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -309,7 +309,7 @@ namespace rose {
       if (const auto score = draw::is_fifty_move_draw(position, ply))
         return *score;
 
-      if (draw::is_repetition(m_hash_stack, m_hash_waterline))
+      if (draw::is_repetition(position, m_hash_stack, m_hash_waterline))
         return 0;
     }
 
@@ -665,7 +665,7 @@ namespace rose {
       if (const auto score = draw::is_fifty_move_draw(position, ply))
         return *score;
 
-      if (draw::is_repetition(m_hash_stack, m_hash_waterline))
+      if (draw::is_repetition(position, m_hash_stack, m_hash_waterline))
         return 0;
     }
 

--- a/tests/test_draw.cpp
+++ b/tests/test_draw.cpp
@@ -1,0 +1,84 @@
+#include "rose/common.hpp"
+#include "rose/game.hpp"
+#include "rose/is_draw.hpp"
+#include "rose/move.hpp"
+#include "rose/util/assert.hpp"
+
+#include <fmt/format.h>
+
+using namespace rose;
+
+static usize hash_waterline = 0;
+
+auto set_waterline(Game& g) -> void {
+  hash_waterline = g.hash_stack().size() - 1;
+}
+
+auto is_repetition(Game& g) -> bool {
+  return draw::is_repetition(g.position(), g.hash_stack(), hash_waterline);
+}
+
+auto move(Game& g, std::string_view move_str) -> void {
+  g.move(Move::parse(move_str, MoveFormat::frc, g.position()).value());
+  fmt::print("{:016x} : {}\n", g.hash(), move_str);
+  rose_assert(g.hash() == g.position().calc_hash_slow());
+}
+
+auto move_and_set_waterline(Game& g, std::string_view move_str) -> void {
+  move(g, move_str);
+  set_waterline(g);
+}
+
+auto repeat_in_search() -> void {
+  Game g;
+  g.reset();
+  fmt::print("{:016x} : startpos\n", g.hash());
+  set_waterline(g);
+  rose_assert(is_repetition(g) == false);
+  move(g, "g1f3");
+  rose_assert(is_repetition(g) == false);
+  move(g, "g8f6");
+  rose_assert(is_repetition(g) == false);
+  move(g, "f3g1");
+  rose_assert(is_repetition(g) == false);
+  move(g, "f6g8");
+  rose_assert(is_repetition(g) == true);
+  move(g, "g1f3");
+  rose_assert(is_repetition(g) == true);
+  move(g, "g8f6");
+  rose_assert(is_repetition(g) == true);
+  move(g, "f3g1");
+  rose_assert(is_repetition(g) == true);
+  move(g, "f6g8");
+  rose_assert(is_repetition(g) == true);
+}
+
+auto repeat_in_prehistory() -> void {
+  Game g;
+  g.reset();
+  fmt::print("{:016x} : startpos\n", g.hash());
+  set_waterline(g);
+  rose_assert(is_repetition(g) == false);
+  move_and_set_waterline(g, "g1f3");
+  rose_assert(is_repetition(g) == false);
+  move_and_set_waterline(g, "g8f6");
+  rose_assert(is_repetition(g) == false);
+  move_and_set_waterline(g, "f3g1");
+  rose_assert(is_repetition(g) == false);
+  move_and_set_waterline(g, "f6g8");
+  rose_assert(is_repetition(g) == false);
+  move_and_set_waterline(g, "g1f3");
+  rose_assert(is_repetition(g) == false);
+  move_and_set_waterline(g, "g8f6");
+  rose_assert(is_repetition(g) == false);
+  move_and_set_waterline(g, "f3g1");
+  rose_assert(is_repetition(g) == false);
+  move_and_set_waterline(g, "f6g8");
+  rose_assert(is_repetition(g) == true);
+}
+
+auto main() -> int {
+  repeat_in_search();
+  repeat_in_prehistory();
+  return 0;
+}


### PR DESCRIPTION
Improves search nps by ~10% (averaged across cluster machines).
Includes a repetition detection test.

VSTC
Elo   | 6.67 +- 4.50 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8076 W: 2160 L: 2005 D: 3911
Penta | [117, 863, 1937, 990, 131]

No functional change.

Bench: 6650691