### PR TITLE
Don't detect repetitions past a null move

### DIFF
--- a/src/rose/is_draw.hpp
+++ b/src/rose/is_draw.hpp
@@ -24,7 +24,7 @@ namespace rose::draw {
 
   inline auto is_repetition(const Position& pos, const std::vector<Hash>& hash_stack, usize hash_waterline) -> bool {
     const int height = static_cast<int>(hash_stack.size()) - 1;
-    const int end = std::min<int>(pos.fifty_move_clock(), height);
+    const int end = std::min<int>(std::min<int>(pos.fifty_move_clock(), pos.ply_since_null()), height);
 
     const auto hash_at = [&hash_stack, height](int i) {
       return hash_stack[height - i];

--- a/src/rose/position.cpp
+++ b/src/rose/position.cpp
@@ -529,6 +529,7 @@ namespace rose {
 #undef MF
 
     new_pos.m_ply++;
+    new_pos.m_since_null++;
     new_pos.m_stm = !m_stm;
 
     observer.on_finalize(new_pos);
@@ -552,6 +553,7 @@ namespace rose {
     }
 
     new_pos.m_50mr++;
+    new_pos.m_since_null = 0;
 
     new_pos.m_ply++;
     new_pos.m_stm = !m_stm;
@@ -944,6 +946,7 @@ namespace rose {
       return std::unexpected(ParseError::out_of_range);
     }
 
+    result.m_since_null = 0;
     result.m_attack_table = result.calc_attacks_slow();
 
     return result;

--- a/src/rose/position.hpp
+++ b/src/rose/position.hpp
@@ -130,6 +130,7 @@ namespace rose {
     std::array<PieceList<PieceType>, 2> m_piece_list_ptype {};
     RookInfo m_rook_info {};
     u16 m_50mr {};
+    u16 m_since_null {};
     u16 m_ply {};
     Square m_enpassant = Square::invalid();
     Color m_stm {};
@@ -178,6 +179,10 @@ namespace rose {
 
     constexpr auto fifty_move_clock() const -> u16 {
       return m_50mr;
+    }
+
+    constexpr auto ply_since_null() const -> u16 {
+      return m_since_null;
     }
 
     constexpr auto full_move_counter() const -> u16 {


### PR DESCRIPTION
STC (non-reg)
Elo   | -0.41 +- 1.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 40414 W: 9678 L: 9726 D: 21010
Penta | [381, 4557, 10402, 4463, 404]

LTC (non-reg)
Elo   | 2.48 +- 3.51 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 9382 W: 2103 L: 2036 D: 5243
Penta | [42, 971, 2596, 1042, 40]

Bench: 5971219