### PR TITLE
Pawn Correction History

### DIFF
--- a/src/rose/cmd/perft.cpp
+++ b/src/rose/cmd/perft.cpp
@@ -24,7 +24,7 @@ namespace rose::perft {
 
     for (Move m : moves) {
       const Position new_position = position.move(m);
-      rose_assert(new_position.calc_hash_slow() == position.hash_after(position.calc_hash_slow(), m));
+      rose_assert(new_position.calc_hashes_slow() == position.hashes_after(position.calc_hashes_slow(), m));
 
       const u64 child = core<false, bulk>(new_position, depth - 1);
       if constexpr (print) {

--- a/src/rose/game.cpp
+++ b/src/rose/game.cpp
@@ -21,8 +21,8 @@ namespace rose {
   }
 
   auto Game::print_hash_stack() const -> void {
-    for (const u64 h : m_hash_stack)
-      fmt::print("{:016x}\n", h);
+    for (const Hashes h : m_hash_stack)
+      fmt::print("{:016x}\n", h.full);
   }
 
 }  // namespace rose

--- a/src/rose/game.hpp
+++ b/src/rose/game.hpp
@@ -11,7 +11,7 @@ namespace rose {
   struct Game {
   private:
     std::vector<Move> m_move_stack;
-    std::vector<Hash> m_hash_stack;
+    std::vector<Hashes> m_hash_stack;
     std::vector<Position> m_position_stack;
 
   public:
@@ -32,14 +32,14 @@ namespace rose {
     }
 
     auto hash() const -> Hash {
-      return m_hash_stack.back();
+      return m_hash_stack.back().full;
     }
 
     auto move_stack() const -> std::vector<Move> {
       return m_move_stack;
     }
 
-    auto hash_stack() const -> std::vector<Hash> {
+    auto hash_stack() const -> std::vector<Hashes> {
       return m_hash_stack;
     }
 
@@ -53,13 +53,13 @@ namespace rose {
       m_hash_stack.clear();
       m_position_stack.clear();
 
-      m_hash_stack.push_back(new_pos.calc_hash_slow());
+      m_hash_stack.push_back(new_pos.calc_hashes_slow());
       m_position_stack.push_back(new_pos);
     }
 
     auto move(Move m) -> void {
       m_move_stack.push_back(m);
-      m_hash_stack.push_back(m_position_stack.back().hash_after(m_hash_stack.back(), m));
+      m_hash_stack.push_back(m_position_stack.back().hashes_after(m_hash_stack.back(), m));
       m_position_stack.emplace_back(m_position_stack.back().move(m));
     }
 

--- a/src/rose/hash.hpp
+++ b/src/rose/hash.hpp
@@ -18,27 +18,42 @@ namespace rose::hash {
 
   inline constexpr Hash move = ~Hash {0};
 
-  inline auto move_piece(Square from, Square to, Place src_place) -> Hash {
-    return piece_table[src_place.raw >> 4][from.raw] ^ piece_table[src_place.raw >> 4][to.raw];
-  }
-
-  inline auto move_piece(Square from, Square to, Color color, PieceType ptype) -> Hash {
-    const usize color_index = color.to_index() << 3;
-    return piece_table[color_index + ptype.raw][from.raw] ^ piece_table[color_index + ptype.raw][to.raw];
-  }
-
-  inline auto promo(Square from, Square to, Color color, PieceType dest_ptype) -> Hash {
-    const usize color_index = color.to_index() << 3;
-    return piece_table[color_index + PieceType::p][from.raw] ^ piece_table[color_index + dest_ptype.raw][to.raw];
-  }
-
-  inline auto remove_piece(Square sq, Place place) -> Hash {
-    return piece_table[place.raw >> 4][sq.raw];
-  }
-
-  inline auto remove_piece(Square sq, Color color, PieceType ptype) -> Hash {
-    const usize color_index = color.to_index() << 3;
-    return piece_table[color_index + ptype.raw][sq.raw];
-  }
-
 }  // namespace rose::hash
+
+namespace rose {
+  struct Hashes {
+    Hash full = 0;
+    Hash pawn = 0;
+
+    constexpr auto operator==(const Hashes&) const -> bool = default;
+
+    inline auto toggle_enpassant(Square enpassant) -> void {
+      full ^= hash::enpassant_table[enpassant.file()];
+    }
+
+    inline auto toggle_castle(usize index) -> void {
+      full ^= hash::castle_table[index];
+    }
+
+    inline auto toggle_piece(Square sq, Place place) -> void {
+      toggle_piece(place.color(), place.ptype(), hash::piece_table[place.raw >> 4][sq.raw]);
+    }
+
+    inline auto toggle_piece(Square sq, Color color, PieceType ptype) -> void {
+      const usize color_index = color.to_index() << 3;
+      toggle_piece(color, ptype, hash::piece_table[color_index + ptype.raw][sq.raw]);
+    }
+
+    inline auto toggle_stm() -> void {
+      full ^= hash::move;
+    }
+
+  private:
+    inline auto toggle_piece(Color color, PieceType ptype, Hash h) -> void {
+      full ^= h;
+
+      if (ptype == PieceType::p)
+        pawn ^= h;
+    }
+  };
+}  // namespace rose

--- a/src/rose/history.hpp
+++ b/src/rose/history.hpp
@@ -2,6 +2,7 @@
 
 #include "rose/bitboard.hpp"
 #include "rose/common.hpp"
+#include "rose/hash.hpp"
 #include "rose/move.hpp"
 #include "rose/square.hpp"
 #include "rose/util/multi_array.hpp"
@@ -93,6 +94,27 @@ namespace rose {
 
     auto get_subtable(Color stm, PieceType ptype, Move mv) -> ContinuationHistorySubtable* {
       return &m_table[stm.to_index()][ptype.to_index()][mv.to().to_index()];
+    }
+  };
+
+  struct HashCorrectionHistory {
+  private:
+    constexpr static usize hash_entry_count = 8192;
+    constexpr static i32 entry_max = 8192;
+    multi_array<i16, Color::count, hash_entry_count> m_table {};
+
+  public:
+    auto reset() -> void {
+      m_table = {};
+    }
+
+    auto update(Color stm, Hash h, i32 bonus) -> void {
+      i16& entry = m_table[stm.to_index()][h % hash_entry_count];
+      gravity_formula<entry_max>(entry, bonus);
+    }
+
+    auto get(Color stm, Hash h) const -> i32 {
+      return m_table[stm.to_index()][h % hash_entry_count];
     }
   };
 

--- a/src/rose/is_draw.hpp
+++ b/src/rose/is_draw.hpp
@@ -22,12 +22,12 @@ namespace rose::draw {
     return 0;
   }
 
-  inline auto is_repetition(const Position& pos, const std::vector<Hash>& hash_stack, usize hash_waterline) -> bool {
+  inline auto is_repetition(const Position& pos, const std::vector<Hashes>& hash_stack, usize hash_waterline) -> bool {
     const int height = static_cast<int>(hash_stack.size()) - 1;
     const int end = std::min<int>(std::min<int>(pos.fifty_move_clock(), pos.ply_since_null()), height);
 
-    const auto hash_at = [&hash_stack, height](int i) {
-      return hash_stack[height - i];
+    const auto hash_at = [&hash_stack, height](int i) -> Hash {
+      return hash_stack[height - i].full;
     };
     const Hash current_hash = hash_at(0);
 

--- a/src/rose/position.cpp
+++ b/src/rose/position.cpp
@@ -561,12 +561,12 @@ namespace rose {
     return new_pos;
   }
 
-  auto Position::hash_after(Hash prev, Move m) const -> Hash {
-    Hash new_hash = prev;
+  auto Position::hashes_after(Hashes prev, Move m) const -> Hashes {
+    Hashes new_hash = prev;
     RookInfo new_rook_info = m_rook_info;
 
     if (m_enpassant.is_valid()) {
-      new_hash ^= hash::enpassant_table[m_enpassant.file()];
+      new_hash.toggle_enpassant(m_enpassant);
     }
 
     const Square from = m.from();
@@ -586,47 +586,56 @@ namespace rose {
     };
 
     const auto normal = [&] {
-      new_hash ^= hash::move_piece(from, to, src_place);
+      new_hash.toggle_piece(from, src_place);
+      new_hash.toggle_piece(to, src_place);
       check_src_castling_rights();
     };
 
     const auto cap_normal = [&] {
-      new_hash ^= hash::remove_piece(to, dest_place);
-      new_hash ^= hash::move_piece(from, to, src_place);
+      new_hash.toggle_piece(to, dest_place);
+      new_hash.toggle_piece(from, src_place);
+      new_hash.toggle_piece(to, src_place);
       check_src_castling_rights();
       check_dest_castling_rights();
     };
 
     const auto promo = [&](auto ptype) {
-      new_hash ^= hash::promo(from, to, m_stm, decltype(ptype)::value);
+      new_hash.toggle_piece(from, src_place);
+      new_hash.toggle_piece(to, m_stm, decltype(ptype)::value);
     };
 
     const auto cap_promo = [&](auto ptype) {
-      new_hash ^= hash::remove_piece(to, dest_place);
-      new_hash ^= hash::promo(from, to, m_stm, decltype(ptype)::value);
+      new_hash.toggle_piece(to, dest_place);
+      new_hash.toggle_piece(from, src_place);
+      new_hash.toggle_piece(to, m_stm, decltype(ptype)::value);
       check_dest_castling_rights();
     };
 
     const auto double_push = [&] {
-      new_hash ^= hash::move_piece(from, to, src_place);
+      new_hash.toggle_piece(from, src_place);
+      new_hash.toggle_piece(to, src_place);
+
       const Square new_enpassant {narrow_cast<u8>((from.raw + to.raw) >> 1)};
-      new_hash ^= hash::enpassant_table[new_enpassant.file()];
+      new_hash.toggle_enpassant(new_enpassant);
     };
 
     const auto enpassant = [&] {
       const Square victim = Square::from_file_and_rank(to.file(), from.rank());
-      new_hash ^= hash::remove_piece(victim, !m_stm, PieceType::p);
-      new_hash ^= hash::move_piece(from, to, src_place);
+      new_hash.toggle_piece(victim, !m_stm, PieceType::p);
+      new_hash.toggle_piece(from, src_place);
+      new_hash.toggle_piece(to, src_place);
     };
 
     const auto castle = [&](u8 king_dest_file, u8 rook_dest_file) {
-      const Square king_dest {narrow_cast<u8>((from.raw & 0x38) | king_dest_file)};
-      const Square rook_dest {narrow_cast<u8>((from.raw & 0x38) | rook_dest_file)};
+      const Square king_dst {narrow_cast<u8>((from.raw & 0x38) | king_dest_file)};
+      const Square rook_dst {narrow_cast<u8>((from.raw & 0x38) | rook_dest_file)};
       const Square king_src = m.from();
       const Square rook_src = m.to();
 
-      new_hash ^= hash::move_piece(king_src, king_dest, m_stm, PieceType::k);
-      new_hash ^= hash::move_piece(rook_src, rook_dest, m_stm, PieceType::r);
+      new_hash.toggle_piece(king_src, m_stm, PieceType::k);
+      new_hash.toggle_piece(king_dst, m_stm, PieceType::k);
+      new_hash.toggle_piece(rook_src, m_stm, PieceType::r);
+      new_hash.toggle_piece(rook_dst, m_stm, PieceType::r);
 
       new_rook_info.clear(m_stm);
     };
@@ -678,34 +687,39 @@ namespace rose {
     }
 #undef MF
 
-    new_hash ^= hash::castle_table[m_rook_info.to_index()];
-    new_hash ^= hash::castle_table[new_rook_info.to_index()];
-    new_hash ^= hash::move;
+    new_hash.toggle_castle(m_rook_info.to_index());
+    new_hash.toggle_castle(new_rook_info.to_index());
+    new_hash.toggle_stm();
 
     return new_hash;
   }
 
-  auto Position::hash_after_null_move(Hash prev) const -> Hash {
-    Hash new_hash = prev;
+  auto Position::hashes_after_null_move(Hashes prev) const -> Hashes {
+    Hashes new_hash = prev;
 
     if (m_enpassant.is_valid()) {
-      new_hash ^= hash::enpassant_table[m_enpassant.file()];
+      new_hash.toggle_enpassant(m_enpassant);
     }
 
-    new_hash ^= hash::move;
+    new_hash.toggle_stm();
 
     return new_hash;
   }
 
-  auto Position::calc_hash_slow() const -> Hash {
-    Hash result = 0;
-    for (u8 sq = 0; sq < 64; sq++)
-      result ^= hash::piece_table[m_board[Square {sq}].raw >> 4][sq];
+  auto Position::calc_hashes_slow() const -> Hashes {
+    Hashes result {};
+
+    for (u8 i = 0; i < 64; i++) {
+      const Square sq {i};
+      result.toggle_piece(sq, m_board[sq]);
+    }
+
     if (m_enpassant.is_valid())
-      result ^= hash::enpassant_table[m_enpassant.file()];
-    result ^= hash::castle_table[m_rook_info.to_index()];
+      result.toggle_enpassant(m_enpassant);
+    result.toggle_castle(m_rook_info.to_index());
     if (m_stm == Color::black)
-      result ^= hash::move;
+      result.toggle_stm();
+
     return result;
   }
 

--- a/src/rose/position.hpp
+++ b/src/rose/position.hpp
@@ -254,9 +254,9 @@ namespace rose {
       return move(m, eval::NullObserver {});
     }
 
-    auto hash_after(Hash prev, Move m) const -> Hash;
-    auto hash_after_null_move(Hash prev) const -> Hash;
-    auto calc_hash_slow() const -> Hash;
+    auto hashes_after(Hashes prev, Move m) const -> Hashes;
+    auto hashes_after_null_move(Hashes prev) const -> Hashes;
+    auto calc_hashes_slow() const -> Hashes;
 
     auto pin_info() const -> std::tuple<const std::array<PieceMask, 64>&, Bitboard>;
     auto calc_pin_info_slow() const -> std::tuple<std::array<PieceMask, 64>, Bitboard>;

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -364,7 +364,7 @@ namespace rose {
         return {std::nullopt, score::none};
 
       const i32 correction = m_sd.pawn_correction_history.get(stm, m_hash_stack.back().pawn);
-      const Score static_eval = score::clamp_normal(raw_static_eval + correction / 1024);
+      const Score static_eval = score::clamp_normal(raw_static_eval + correction / 64);
       return {correction, static_eval};
     }();
     ss->static_eval = static_eval;

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -149,7 +149,7 @@ namespace rose {
         m_hash_stack = g.hash_stack();
         m_hash_waterline = std::max<usize>(1, m_hash_stack.size()) - 1;
 
-        rose_assert(m_hash_stack.back() == m_root.calc_hash_slow());
+        rose_assert(m_hash_stack.back() == m_root.calc_hashes_slow());
 
         const auto ctrl = is_main_thread() ? calc_ctrl(m_shared.search_start_time, m_shared.search_main_limits, m_root.stm()) :
                                              controls::None {.start_time = m_shared.search_start_time};
@@ -793,20 +793,20 @@ namespace rose {
   auto Search<Evaluation>::tt_load() -> tt::LookupResult {
     rose_assert(m_hash_stack.size() > m_hash_waterline);
     const i32 ply = static_cast<i32>(m_hash_stack.size() - 1 - m_hash_waterline);
-    return m_shared.transposition_table.load(m_hash_stack.back(), ply);
+    return m_shared.transposition_table.load(m_hash_stack.back().full, ply);
   }
 
   template<eval::concepts::State Evaluation>
   auto Search<Evaluation>::tt_store(tt::LookupResult lr) -> void {
     rose_assert(m_hash_stack.size() > m_hash_waterline);
     const i32 ply = static_cast<i32>(m_hash_stack.size() - 1 - m_hash_waterline);
-    m_shared.transposition_table.store(m_hash_stack.back(), ply, lr);
+    m_shared.transposition_table.store(m_hash_stack.back().full, ply, lr);
   }
 
   template<eval::concepts::State Evaluation>
   auto Search<Evaluation>::make_move(SearchStack* ss, const Position& position, Move mv) -> Position {
     m_evaluation.push();
-    m_hash_stack.push_back(position.hash_after(m_hash_stack.back(), mv));
+    m_hash_stack.push_back(position.hashes_after(m_hash_stack.back(), mv));
     const Position child_position = position.move(mv, m_evaluation.observer());
     ss->move = mv;
     ss->conthist = m_sd.continuation_history.get_subtable(!child_position.stm(), child_position.ptype_at(mv.to()), mv);
@@ -817,7 +817,7 @@ namespace rose {
   template<eval::concepts::State Evaluation>
   auto Search<Evaluation>::make_null_move(SearchStack* ss, const Position& position) -> Position {
     m_evaluation.push();
-    m_hash_stack.push_back(position.hash_after_null_move(m_hash_stack.back()));
+    m_hash_stack.push_back(position.hashes_after_null_move(m_hash_stack.back()));
     const Position child_position = position.null_move();
     ss->move = Move::none();
     ss->conthist = nullptr;

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -348,14 +348,24 @@ namespace rose {
       return tte.score;
     }
 
-    const Score static_eval = [&, this] {
+    const Score raw_static_eval = [&, this] {
       if (is_in_check)
         return score::none;
-      if (ss->static_eval != score::none)
-        return ss->static_eval;
-      if (tte.eval != score::none)
-        return tte.eval;
+      if (ss->raw_static_eval != score::none)
+        return ss->raw_static_eval;
+      if (tte.raw_eval != score::none)
+        return tte.raw_eval;
       return eval(position);
+    }();
+    ss->raw_static_eval = raw_static_eval;
+
+    const auto [correction, static_eval] = [&, this] -> std::tuple<std::optional<i32>, Score> {
+      if (is_in_check)
+        return {std::nullopt, score::none};
+
+      const i32 correction = m_sd.pawn_correction_history.get(stm, m_hash_stack.back().pawn);
+      const Score static_eval = score::clamp_normal(raw_static_eval + correction / 1024);
+      return {correction, static_eval};
     }();
     ss->static_eval = static_eval;
 
@@ -638,11 +648,27 @@ namespace rose {
     }
 
     if (!excluded) {
+      if (!is_in_check && !best_move.is_noisy() && [&] {
+            switch (actual_node_type.raw) {
+            case NodeType::pv:
+              return true;
+            case NodeType::all:
+              return best_score < static_eval;
+            case NodeType::cut:
+              return best_score > static_eval;
+            case NodeType::none:
+              return false;
+            }
+          }()) {
+        const i32 bonus = (best_score - static_eval) * depth / 4;
+        m_sd.pawn_correction_history.update(stm, m_hash_stack.back().pawn, bonus);
+      }
+
       tt_store(tt::LookupResult {
         .depth = depth,
         .bound = actual_node_type,
         .score = best_score,
-        .eval = static_eval,
+        .raw_eval = raw_static_eval,
         .move = best_move,
       });
     }
@@ -681,6 +707,7 @@ namespace rose {
     }
 
     const bool is_in_check = position.is_in_check();
+    const Color stm = position.stm();
 
     const tt::LookupResult tte = tt_load();
 
@@ -700,14 +727,24 @@ namespace rose {
       return tte.score;
     }
 
-    const Score static_eval = [&, this] {
+    const Score raw_static_eval = [&, this] {
       if (is_in_check)
         return score::none;
-      if (ss->static_eval != score::none)
-        return ss->static_eval;
-      if (tte.eval != score::none)
-        return tte.eval;
+      if (ss->raw_static_eval != score::none)
+        return ss->raw_static_eval;
+      if (tte.raw_eval != score::none)
+        return tte.raw_eval;
       return eval(position);
+    }();
+    ss->raw_static_eval = raw_static_eval;
+
+    const auto [correction, static_eval] = [&, this] -> std::tuple<std::optional<i32>, Score> {
+      if (is_in_check)
+        return {std::nullopt, score::none};
+
+      const i32 correction = m_sd.pawn_correction_history.get(stm, m_hash_stack.back().pawn);
+      const Score static_eval = score::clamp_normal(raw_static_eval + correction / 1024);
+      return {correction, static_eval};
     }();
     ss->static_eval = static_eval;
 
@@ -777,7 +814,7 @@ namespace rose {
       .depth = 0,
       .bound = actual_node_type,
       .score = best_score,
-      .eval = static_eval,
+      .raw_eval = raw_static_eval,
       .move = best_move,
     });
 
@@ -810,6 +847,7 @@ namespace rose {
     const Position child_position = position.move(mv, m_evaluation.observer());
     ss->move = mv;
     ss->conthist = m_sd.continuation_history.get_subtable(!child_position.stm(), child_position.ptype_at(mv.to()), mv);
+    ss[1].raw_static_eval = score::none;
     ss[1].static_eval = score::none;
     return child_position;
   }
@@ -821,6 +859,7 @@ namespace rose {
     const Position child_position = position.null_move();
     ss->move = Move::none();
     ss->conthist = nullptr;
+    ss[1].raw_static_eval = score::none;
     ss[1].static_eval = score::none;
     return child_position;
   }
@@ -831,6 +870,7 @@ namespace rose {
     m_hash_stack.pop_back();
     ss->move = Move::none();
     ss->conthist = nullptr;
+    ss[1].raw_static_eval = score::none;
     ss[1].static_eval = score::none;
   }
 

--- a/src/rose/search.hpp
+++ b/src/rose/search.hpp
@@ -92,6 +92,7 @@ namespace rose {
   struct SearchStack {
     Move move = Move::none();
     Move excluded = Move::none();
+    Score raw_static_eval = score::none;
     Score static_eval = score::none;
     i32 reduction = 0;
     ContinuationHistorySubtable* conthist = nullptr;
@@ -101,11 +102,13 @@ namespace rose {
     QuietHistory quiet_history;
     NoisyHistory noisy_history;
     ContinuationHistory continuation_history;
+    HashCorrectionHistory pawn_correction_history;
 
     auto reset() -> void {
       quiet_history.reset();
       noisy_history.reset();
       continuation_history.reset();
+      pawn_correction_history.reset();
     }
   };
 

--- a/src/rose/search.hpp
+++ b/src/rose/search.hpp
@@ -127,7 +127,7 @@ namespace rose {
 
     Position m_root;
     std::vector<Move> m_move_stack;
-    std::vector<Hash> m_hash_stack;
+    std::vector<Hashes> m_hash_stack;
     usize m_hash_waterline;
 
     inline static constexpr usize search_stack_offset = 8;

--- a/src/rose/tt.hpp
+++ b/src/rose/tt.hpp
@@ -17,7 +17,7 @@ namespace rose::tt {
     i32 depth = 0;
     NodeType bound = NodeType::none;
     Score score = score::none;
-    Score eval = score::none;
+    Score raw_eval = score::none;
     Move move = Move::none();
 
     auto is_none() const -> bool {
@@ -37,8 +37,8 @@ namespace rose::tt {
     // u2 bounds
     // u5 age
     // u1 unused
-    // i16 eval
-    static inline constexpr usize eval_shift = 0;
+    // i16 raw_eval
+    static inline constexpr usize raw_eval_shift = 0;
     static inline constexpr usize age_shift = 17;
     static inline constexpr usize bounds_shift = 22;
     static inline constexpr usize depth_shift = 24;
@@ -54,10 +54,10 @@ namespace rose::tt {
       const i32 tt_score = score::adjust_plys_to_mate(lr.score, -ply);
       const i32 tt_depth = std::clamp(lr.depth, 0, 255);
       const u64 tt_bound = std::to_underlying(lr.bound.raw);
-      const u64 tt_eval = static_cast<u64>(lr.eval) & 0xFFFF;
+      const u64 tt_raw_eval = static_cast<u64>(lr.raw_eval) & 0xFFFF;
 
       raw = 0;
-      raw |= static_cast<u64>(tt_eval) << eval_shift;
+      raw |= static_cast<u64>(tt_raw_eval) << raw_eval_shift;
       raw |= static_cast<u64>(age & age_mask) << age_shift;
       raw |= static_cast<u64>(tt_bound) << bounds_shift;
       raw |= static_cast<u64>(tt_depth) << depth_shift;
@@ -65,9 +65,9 @@ namespace rose::tt {
       raw |= static_cast<u64>(tt_score) << score_shift;
     }
 
-    constexpr inline auto eval() const -> Score {
+    constexpr inline auto raw_eval() const -> Score {
       const usize sext_shift = 64 - 16;
-      return static_cast<Score>(static_cast<i64>(raw >> eval_shift << sext_shift) >> sext_shift);
+      return static_cast<Score>(static_cast<i64>(raw >> raw_eval_shift << sext_shift) >> sext_shift);
     }
 
     constexpr inline auto age() const -> int {
@@ -96,7 +96,7 @@ namespace rose::tt {
         .depth = depth(),
         .bound = bound(),
         .score = score(ply),
-        .eval = eval(),
+        .raw_eval = raw_eval(),
         .move = move(),
       };
     }

--- a/tests/test_draw.cpp
+++ b/tests/test_draw.cpp
@@ -21,7 +21,7 @@ auto is_repetition(Game& g) -> bool {
 auto move(Game& g, std::string_view move_str) -> void {
   g.move(Move::parse(move_str, MoveFormat::frc, g.position()).value());
   fmt::print("{:016x} : {}\n", g.hash(), move_str);
-  rose_assert(g.hash() == g.position().calc_hash_slow());
+  rose_assert(g.hash() == g.position().calc_hashes_slow().full);
 }
 
 auto move_and_set_waterline(Game& g, std::string_view move_str) -> void {


### PR DESCRIPTION
STC
Elo   | 16.82 +- 7.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2708 W: 731 L: 600 D: 1377
Penta | [25, 286, 616, 387, 40]

LTC
Elo   | 10.90 +- 5.86 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3954 W: 966 L: 842 D: 2146
Penta | [17, 432, 974, 518, 36]

Bench: 6808623