### PR TITLE
Move Singular Extensions before move loop

### DIFF
--- a/src/rose/move_picker.cpp
+++ b/src/rose/move_picker.cpp
@@ -12,23 +12,24 @@
 
 namespace rose {
 
-  MovePicker::MovePicker(const SearchData& sd, const Position& position, const SearchStack* ss, Move tt_move) :
+  MovePicker::MovePicker(const SearchData& sd, const Position& position, const SearchStack* ss, Move hint_move) :
       m_sd(sd),
       m_position(position),
       m_ss(ss),
       m_movegen(position),
-      m_tt_move(tt_move) {
+      m_hint_move(hint_move) {
   }
 
   auto MovePicker::next() -> Move {
     switch (m_stage) {
-    case Stage::tt_move:
+    case Stage::hint_move:
       m_stage = Stage::generate_noisy;
 
-      if (m_position.is_legal(m_tt_move)) {
-        return m_tt_move;
+      if (m_hint_move.is_some()) {
+        return m_hint_move;
       }
 
+      [[fallthrough]];
     case Stage::generate_noisy:
       generate_noisy();
 
@@ -43,7 +44,7 @@ namespace rose {
           m_bad_noisies.push_back(mv);
           continue;
         }
-        if (mv == m_tt_move)
+        if (mv == m_hint_move)
           continue;
         return mv;
       }
@@ -68,7 +69,7 @@ namespace rose {
     case Stage::emit_quiet:
       while (m_current_index < m_moves.size()) {
         const Move mv = m_moves[m_current_index++];
-        if (mv == m_tt_move)
+        if (mv == m_hint_move)
           continue;
         return mv;
       }
@@ -80,7 +81,7 @@ namespace rose {
     case Stage::emit_bad_noisy:
       while (m_current_index < m_bad_noisies.size()) {
         const Move mv = m_bad_noisies[m_current_index++];
-        if (mv == m_tt_move)
+        if (mv == m_hint_move)
           continue;
         return mv;
       }

--- a/src/rose/move_picker.hpp
+++ b/src/rose/move_picker.hpp
@@ -12,7 +12,7 @@ namespace rose {
   struct MovePicker {
   private:
     enum class Stage {
-      tt_move,
+      hint_move,
       generate_noisy,
       emit_good_noisy,
       generate_quiet,
@@ -25,13 +25,13 @@ namespace rose {
       return m_stage >= Stage::generate_quiet && m_stage <= Stage::emit_quiet;
     }
 
-    Stage m_stage = Stage::tt_move;
+    Stage m_stage = Stage::hint_move;
 
     const SearchData& m_sd;
     const Position& m_position;
     const SearchStack* m_ss;
     MoveGen m_movegen;
-    Move m_tt_move;
+    Move m_hint_move;
 
     bool m_skip_quiet = false;
     usize m_current_index = 0;
@@ -39,7 +39,8 @@ namespace rose {
     MoveList m_bad_noisies;
 
   public:
-    MovePicker(const SearchData& sd, const Position& position, const SearchStack* ss, Move tt_move);
+    // SAFETY: hint_move must be legal
+    MovePicker(const SearchData& sd, const Position& position, const SearchStack* ss, Move hint_move);
 
     auto next() -> Move;
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -445,6 +445,42 @@ namespace rose {
         return iid_tte.score;
     }
 
+    // Hint move legality check
+    if (!position.is_legal(hint_move)) {
+      hint_move = Move::none();
+    }
+
+    // Singular Extensions
+    i32 extension = 0;
+    if (!is_root && depth >= 7 && hint_move.is_some() && !excluded && tte.depth >= depth - 3 && tte.bound.is_pv_or_cut()) {
+      const Score singular_beta = std::max(score::min_score, tte.score - 2 * depth);
+      const i32 singular_depth = depth / 2;
+
+      ss->excluded = hint_move;
+      const Score singular_score = search<expected.narrow()>(ctrl, position, pv, singular_beta - 1, singular_beta, ss, ply, singular_depth);
+      ss->excluded = Move::none();
+
+      // Multicut
+      if (singular_score >= singular_beta && singular_beta >= beta) {
+        return singular_beta;
+      }
+
+      if (singular_score < singular_beta) {
+        // Single extension
+        extension = 1;
+        // Double extension
+        extension += expected != NodeType::pv && singular_score <= singular_beta - 21_z;
+        // Triple extension
+        extension += expected != NodeType::pv && singular_score <= singular_beta - 131_z;
+      }
+      // Negative extension
+      else if (expected == NodeType::cut || tte.score >= beta) {
+        extension = -2;
+      } else if (tte.score <= alpha) {
+        extension = -1;
+      }
+    }
+
     MovePicker moves {m_sd, position, ss, hint_move};
 
     MoveList fail_low_quiets;
@@ -499,37 +535,6 @@ namespace rose {
         // Noisy SEE Pruning
         if (mv.is_noisy() && depth <= 11 && !see::see(position, mv, -73_z * depth)) {
           continue;
-        }
-      }
-
-      i32 extension = 0;
-      // Singular Extensions
-      if (!is_root && depth >= 7 && mv == tte.move && !excluded && tte.depth >= depth - 3 && tte.bound.is_pv_or_cut()) {
-        const Score singular_beta = std::max(score::min_score, tte.score - 2 * depth);
-        const i32 singular_depth = depth / 2;
-
-        ss->excluded = mv;
-        const Score singular_score = search<expected.narrow()>(ctrl, position, pv, singular_beta - 1, singular_beta, ss, ply, singular_depth);
-        ss->excluded = Move::none();
-
-        // Multicut
-        if (singular_score >= singular_beta && singular_beta >= beta) {
-          return singular_beta;
-        }
-
-        if (singular_score < singular_beta) {
-          // Single extension
-          extension = 1;
-          // Double extension
-          extension += expected != NodeType::pv && singular_score <= singular_beta - 21_z;
-          // Triple extension
-          extension += expected != NodeType::pv && singular_score <= singular_beta - 131_z;
-        }
-        // Negative extension
-        else if (expected == NodeType::cut) {
-          extension = -2;
-        } else if (tte.score <= alpha) {
-          extension = -1;
         }
       }
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -542,7 +542,7 @@ namespace rose {
         unmake_move(ss);
       };
 
-      const i32 new_depth = depth + extension - 1;
+      const i32 new_depth = depth + (mv == hint_move ? extension : 0) - 1;
       Line child_pv {};
       Score score = score::none;
 

--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -474,7 +474,7 @@ namespace rose {
         extension += expected != NodeType::pv && singular_score <= singular_beta - 131_z;
       }
       // Negative extension
-      else if (expected == NodeType::cut || tte.score >= beta) {
+      else if (expected == NodeType::cut) {
         extension = -2;
       } else if (tte.score <= alpha) {
         extension = -1;


### PR DESCRIPTION
FN non-reg
Elo   | -0.00 +- 0.00 (95%)
SPRT  | N=10000 Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 14082 W: 4731 L: 4731 D: 4620
Penta | [0, 0, 7041, 0, 0]

No functional change.

Bench: 7080100