### PR TITLE
Increase increment fraction 1/3 → 3/4

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -99,8 +99,8 @@ namespace rose {
       safe_remaining_ms = std::min(safe_remaining_ms, movetime_ms);
     }
 
-    const auto hard_limit = std::min<time::Milliseconds>(safe_remaining_ms / movestogo * 7_z + increment_ms / 3, safe_remaining_ms);
-    const auto soft_limit = std::min<time::Milliseconds>(safe_remaining_ms / movestogo + increment_ms / 3, safe_remaining_ms);
+    const auto hard_limit = std::min<time::Milliseconds>(safe_remaining_ms / movestogo * 7_z + increment_ms * 3 / 4, safe_remaining_ms);
+    const auto soft_limit = std::min<time::Milliseconds>(safe_remaining_ms / movestogo + increment_ms * 3 / 4, safe_remaining_ms);
 
     return {hard_limit, soft_limit};
   }


### PR DESCRIPTION
```
Elo   | 7.76 +- 4.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6044 W: 1548 L: 1413 D: 3083
Penta | [50, 634, 1531, 745, 62]
```
https://asylum.red/test/6073/

```
Elo   | 7.63 +- 4.55 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5422 W: 1255 L: 1136 D: 3031
Penta | [19, 524, 1505, 645, 18]
```
https://asylum.red/test/6075/

Bench: 7080100