### PR TITLE
Prefetch upcoming transposition table access

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -893,6 +893,7 @@ namespace rose {
   auto Search<Evaluation>::make_move(SearchStack* ss, const Position& position, Move mv) -> Position {
     m_evaluation.push();
     m_hash_stack.push_back(position.hashes_after(m_hash_stack.back(), mv));
+    m_shared.transposition_table.prefetch(m_hash_stack.back().full());
     const Position child_position = position.move(mv, m_evaluation.observer());
     ss->move = mv;
     ss->conthist = m_sd.continuation_history.get_subtable(!child_position.stm(), child_position.ptype_at(mv.to()), mv);

--- a/src/rose/tt.cpp
+++ b/src/rose/tt.cpp
@@ -6,16 +6,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <fmt/format.h>
-#include <tuple>
 
 namespace rose::tt {
-
-  static constexpr inline auto split_hash(usize count, u64 hash) -> std::tuple<usize, u64> {
-    const u128 mul = static_cast<u128>(hash) * count;
-    const usize index = static_cast<usize>(mul >> 64);
-    const u64 fragment = (static_cast<u64>(mul) >> (64 - Bucket::fragment_width)) & Bucket::fragment_mask;
-    return {index, fragment};
-  }
 
 #ifdef _WIN32
 
@@ -43,7 +35,7 @@ namespace rose::tt {
     std::memset(m_table.get(), 0, m_count * sizeof(Bucket));
   }
 
-  auto TT::load(u64 hash, int ply) const -> LookupResult {
+  auto TT::load(Hash hash, int ply) const -> LookupResult {
     const auto [index, fragment] = split_hash(m_count, hash);
     const Bucket& bucket = m_table.get()[index];
 
@@ -54,7 +46,7 @@ namespace rose::tt {
     return {};
   }
 
-  auto TT::store(u64 hash, int ply, LookupResult lr) -> void {
+  auto TT::store(Hash hash, int ply, LookupResult lr) -> void {
     const auto retention_score = [this](const Entry& e) {
       constexpr int max_age = Entry::age_mask + 1;
       return e.depth() - (max_age + m_age - e.age()) % max_age * 4;
@@ -96,7 +88,7 @@ namespace rose::tt {
     bucket.set_fragment(best_index, fragment);
   }
 
-  auto TT::print(u64 hash) const -> void {
+  auto TT::print(Hash hash) const -> void {
     const auto [index, fragment] = split_hash(m_count, hash);
     fmt::print("hash:   {:016x}\n", hash);
     fmt::print("frag:   {:06x}\n", fragment);

--- a/src/rose/tt.hpp
+++ b/src/rose/tt.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
 #include "rose/common.hpp"
+#include "rose/hash.hpp"
 #include "rose/move.hpp"
 #include "rose/node_type.hpp"
 #include "rose/score.hpp"
 
 #include <bit>
 #include <memory>
+#include <tuple>
 
 namespace rose::tt {
 
@@ -139,6 +141,13 @@ namespace rose::tt {
     return mb * 1024 * 1024 / sizeof(Bucket);
   }
 
+  constexpr inline auto split_hash(usize count, Hash hash) -> std::tuple<usize, u64> {
+    const u128 mul = static_cast<u128>(hash) * count;
+    const usize index = static_cast<usize>(mul >> 64);
+    const u64 fragment = (static_cast<u64>(mul) >> (64 - Bucket::fragment_width)) & Bucket::fragment_mask;
+    return {index, fragment};
+  }
+
   struct TT {
   private:
     static auto table_alloc(std::size_t m_count) -> Bucket*;
@@ -167,10 +176,16 @@ namespace rose::tt {
       m_age = (m_age + 1) & Entry::age_mask;
     }
 
-    auto load(u64 hash, int ply) const -> LookupResult;
-    auto store(u64 hash, int ply, LookupResult lr) -> void;
+    auto prefetch(Hash hash) -> void {
+      const auto [index, fragment] = split_hash(m_count, hash);
+      const Bucket& bucket = m_table.get()[index];
+      __builtin_prefetch(&bucket, 0, 2);
+    }
 
-    auto print(u64 hash) const -> void;
+    auto load(Hash hash, int ply) const -> LookupResult;
+    auto store(Hash hash, int ply, LookupResult lr) -> void;
+
+    auto print(Hash hash) const -> void;
   };
 
 }  // namespace rose::tt


### PR DESCRIPTION
VSTC
Elo   | 19.85 +- 8.69 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2436 W: 737 L: 598 D: 1101
Penta | [39, 235, 556, 324, 64]

Bench: 7080100