### PR TITLE
Prefetch transposition table entry for null moves

### DIFF
--- a/src/rose/search.cpp
+++ b/src/rose/search.cpp
@@ -906,6 +906,7 @@ namespace rose {
   auto Search<Evaluation>::make_null_move(SearchStack* ss, const Position& position) -> Position {
     m_evaluation.push();
     m_hash_stack.push_back(position.hashes_after_null_move(m_hash_stack.back()));
+    m_shared.transposition_table.prefetch(m_hash_stack.back().full());
     const Position child_position = position.null_move();
     ss->move = Move::none();
     ss->conthist = nullptr;


### PR DESCRIPTION
VSTC (failed)
Elo   | 1.21 +- 1.24 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 5.00]
Games | N: 110682 W: 30143 L: 29756 D: 50783
Penta | [1841, 12686, 26050, 12773, 1991]

Would pass a non-reg; and I would prefer having it for consistency.

Bench: 7080100